### PR TITLE
use `addr` instead `unsafeAddr`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: jiro4989/setup-nim-action@v1
         with:
-         nim-version: 1.6.12
+         nim-version: devel
          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - if: runner.os == 'Linux'
         name: prepare

--- a/examples/blend.nim
+++ b/examples/blend.nim
@@ -43,7 +43,7 @@ proc init() {.cdecl.} =
   ]
   bindings.vertexBuffers[0] = sg.makeBuffer(BufferDesc(
       type: bufferTypeVertexBuffer,
-      data: sg.Range(addr: vertices.unsafeAddr, size: vertices.sizeof)
+      data: sg.Range(addr: vertices.addr, size: vertices.sizeof)
     ))
 
   # pipeline object for rendering the background
@@ -87,7 +87,7 @@ proc frame() {.cdecl.} =
   tick += 1.0 * time
   sg.applyPipeline(bgPip)
   sg.applyBindings(bindings)
-  sg.applyUniforms(shaderStageFs, shd.slotBgFsParams, sg.Range(addr: bgFsParams.unsafeAddr, size: bgFsParams.sizeof))
+  sg.applyUniforms(shaderStageFs, shd.slotBgFsParams, sg.Range(addr: bgFsParams.addr, size: bgFsParams.sizeof))
   sg.draw(0, 4, 1)
 
   # draw the blended quads
@@ -109,7 +109,7 @@ proc frame() {.cdecl.} =
       let quadVsParams = QuadVsParams(mvp: viewProj * model)
       sg.applyPipeline(pip[src][dst])
       sg.applyBindings(bindings)
-      sg.applyUniforms(shaderStageVs, shd.slotQuadVsParams, sg.Range(addr: quadVsParams.unsafeAddr, size: quadVsParams.sizeof))
+      sg.applyUniforms(shaderStageVs, shd.slotQuadVsParams, sg.Range(addr: quadVsParams.addr, size: quadVsParams.sizeof))
       sg.draw(0, 4, 1)
       r0 += 0.6
   sg.endPass()

--- a/examples/bufferoffsets.nim
+++ b/examples/bufferoffsets.nim
@@ -47,11 +47,11 @@ proc init() {.cdecl.} =
     0, 1, 2, 0, 2, 3
   ]
   bindings.vertexBuffers[0] = sg.makeBuffer(BufferDesc(
-    data: sg.Range(addr: vertices.unsafeAddr, size: vertices.sizeof)
+    data: sg.Range(addr: vertices.addr, size: vertices.sizeof)
   ))
   bindings.indexBuffer = sg.makeBuffer(BufferDesc(
     type: bufferTypeIndexBuffer,
-    data: sg.Range(addr: indices.unsafeAddr, size: indices.sizeof)
+    data: sg.Range(addr: indices.addr, size: indices.sizeof)
   ))
 
   # shader and pipeline object

--- a/examples/cube.nim
+++ b/examples/cube.nim
@@ -62,7 +62,7 @@ proc init() {.cdecl.} =
      1.0,  1.0, -1.0,      1.0, 0.0, 0.5, 1.0,
   ]
   let vbuf = sg.makeBuffer(BufferDesc(
-    data: sg.Range(addr: vertices.unsafeAddr, size: vertices.sizeof)
+    data: sg.Range(addr: vertices.addr, size: vertices.sizeof)
   ))
 
   const indices = [
@@ -75,7 +75,7 @@ proc init() {.cdecl.} =
   ]
   let ibuf = sg.makeBuffer(BufferDesc(
     type: bufferTypeIndexBuffer,
-    data: sg.Range(addr: indices.unsafeAddr, size: indices.sizeof)
+    data: sg.Range(addr: indices.addr, size: indices.sizeof)
   ))
 
   pip = sg.makePipeline(PipelineDesc(
@@ -115,7 +115,7 @@ proc frame() {.cdecl.} =
   sg.beginDefaultPass(passAction, sapp.width(), sapp.height())
   sg.applyPipeline(pip)
   sg.applyBindings(bindings)
-  sg.applyUniforms(shaderStageVs, shd.slotVsParams, sg.Range(addr: vsParams.unsafeAddr, size: vsParams.sizeof))
+  sg.applyUniforms(shaderStageVs, shd.slotVsParams, sg.Range(addr: vsParams.addr, size: vsParams.sizeof))
   sg.draw(0, 36, 1)
   sg.endPass()
   sg.commit()

--- a/examples/debugtextuserfont.nim
+++ b/examples/debugtextuserfont.nim
@@ -182,7 +182,7 @@ proc init() {.cdecl.} =
   sdtx.setup(sdtx.Desc(
     fonts: [
       sdtx.FontDesc(
-        data: sdtx.Range(addr: userFont.unsafeAddr, size: userFont.sizeof),
+        data: sdtx.Range(addr: userFont.addr, size: userFont.sizeof),
         firstChar: 0x20,
         lastChar: 0x9F
       )

--- a/examples/instancing.nim
+++ b/examples/instancing.nim
@@ -48,7 +48,7 @@ proc init() {.cdecl.} =
     0.0f,    r, 0.0f,       1.0f, 0.0f, 1.0f, 1.0f
   ]
   bindings.vertexBuffers[0] = sg.makeBuffer(BufferDesc(
-    data: sg.Range(addr: vertices.unsafeAddr, size: vertices.sizeof)
+    data: sg.Range(addr: vertices.addr, size: vertices.sizeof)
   ))
 
   # index buffer for static geometry
@@ -58,7 +58,7 @@ proc init() {.cdecl.} =
   ]
   bindings.indexBuffer = sg.makeBuffer(BufferDesc(
     type: bufferTypeIndexBuffer,
-    data: sg.Range(addr: indices.unsafeAddr, size: indices.sizeof)
+    data: sg.Range(addr: indices.addr, size: indices.sizeof)
   ))
 
   # empty, dynamic instance-data vertex buffer, goes into vertex-buffer-slot 1
@@ -119,7 +119,7 @@ proc frame() {.cdecl.} =
   # update instance data
   # FIXME: this is awkward, we'd need a slice-to-Range converter
   sg.updateBuffer(bindings.vertexBuffers[1], sg.Range(
-    addr: pos.unsafeAddr,
+    addr: pos.addr,
     size: (curNumParticles * Vec3.sizeof)
   ))
 
@@ -134,7 +134,7 @@ proc frame() {.cdecl.} =
   sg.beginDefaultPass(passAction, sapp.width(), sapp.height())
   sg.applyPipeline(pip)
   sg.applyBindings(bindings)
-  sg.applyUniforms(shaderStageVs, shd.slotVsParams, sg.Range(addr: vsParams.unsafeAddr, size: vsParams.sizeof))
+  sg.applyUniforms(shaderStageVs, shd.slotVsParams, sg.Range(addr: vsParams.addr, size: vsParams.sizeof))
   sg.draw(0, 24, curNumParticles.int32)
   sg.endPass()
   sg.commit()

--- a/examples/mrt.nim
+++ b/examples/mrt.nim
@@ -122,7 +122,7 @@ proc init() {.cdecl.} =
     Vertex(x:  1.0f, y:  1.0f, z: -1.0f, b: 0.7f),
   ]
   offscreenBindings.vertexBuffers[0] = sg.makeBuffer(BufferDesc(
-    data: sg.Range(addr: cubeVertices.unsafeAddr, size: cubeVertices.sizeof)
+    data: sg.Range(addr: cubeVertices.addr, size: cubeVertices.sizeof)
   ))
 
   # cube index buffer
@@ -136,7 +136,7 @@ proc init() {.cdecl.} =
   ]
   offscreenBindings.indexBuffer = sg.makeBuffer(BufferDesc(
     type: bufferTypeIndexBuffer,
-    data: sg.Range(addr: cubeIndices.unsafeAddr, size: cubeIndices.sizeof)
+    data: sg.Range(addr: cubeIndices.addr, size: cubeIndices.sizeof)
   ))
 
   # shader and pipeline for offscreen-renderer cube
@@ -163,7 +163,7 @@ proc init() {.cdecl.} =
   # a vertex buffer to create a fullscreen rectangle
   const quadVertices = [ 0.0f, 0.0f,  1.0f, 0.0f,  0.0f, 1.0f,  1.0f, 1.0f ]
   let quadVbuf = sg.makeBuffer(BufferDesc(
-    data: sg.Range(addr: quadVertices.unsafeAddr, size: quadVertices.sizeof)
+    data: sg.Range(addr: quadVertices.addr, size: quadVertices.sizeof)
   ))
 
   # shader, pipeline and bindings to compose 3 offscreen render targets into default framebuffer
@@ -218,7 +218,7 @@ proc frame() {.cdecl.} =
   sg.beginPass(offscreenPass, offscreenPassAction)
   sg.applyPipeline(offscreenPip)
   sg.applyBindings(offscreenBindings)
-  sg.applyUniforms(shaderStageVs, shd.slotOffscreenParams, sg.Range(addr: offscreenParams.unsafeAddr, size: offscreenParams.sizeof))
+  sg.applyUniforms(shaderStageVs, shd.slotOffscreenParams, sg.Range(addr: offscreenParams.addr, size: offscreenParams.sizeof))
   sg.draw(0, 36, 1)
   sg.endPass()
 
@@ -226,7 +226,7 @@ proc frame() {.cdecl.} =
   sg.beginDefaultPass(defaultPassAction, sapp.width(), sapp.height())
   sg.applyPipeline(fsqPip)
   sg.applyBindings(fsqBindings)
-  sg.applyUniforms(shaderStageVs, shd.slotFsqParams, sg.Range(addr: fsqParams.unsafeAddr, size: fsqParams.sizeof))
+  sg.applyUniforms(shaderStageVs, shd.slotFsqParams, sg.Range(addr: fsqParams.addr, size: fsqParams.sizeof))
   sg.draw(0, 4, 1)
   sg.applyPipeline(dbgPip)
   for i in 0..<3:

--- a/examples/noninterleaved.nim
+++ b/examples/noninterleaved.nim
@@ -46,7 +46,7 @@ proc init() {.cdecl.} =
     1.0, 1.0, 0.5, 1.0,  1.0, 1.0, 0.5, 1.0,  1.0, 1.0, 0.5, 1.0,  1.0, 1.0, 0.5, 1.0,
   ]
   let vbuf = sg.makeBuffer(BufferDesc(
-    data: sg.Range(addr: vertices.unsafeAddr, size: vertices.sizeof)
+    data: sg.Range(addr: vertices.addr, size: vertices.sizeof)
   ))
 
   # cube index buffer
@@ -60,7 +60,7 @@ proc init() {.cdecl.} =
   ]
   let ibuf = sg.makeBuffer(BufferDesc(
       type: bufferTypeIndexBuffer,
-      data: sg.Range(addr: indices.unsafeAddr, size: indices.sizeof)
+      data: sg.Range(addr: indices.addr, size: indices.sizeof)
   ))
 
   # shader and pipeline object
@@ -106,7 +106,7 @@ proc frame() {.cdecl.} =
   sg.beginDefaultPass(passAction, sapp.width(), sapp.height())
   sg.applyPipeline(pip)
   sg.applyBindings(bindings)
-  sg.applyUniforms(shaderStageVs, shd.slotVsParams, sg.Range(addr: vsParams.unsafeAddr, size: vsParams.sizeof))
+  sg.applyUniforms(shaderStageVs, shd.slotVsParams, sg.Range(addr: vsParams.addr, size: vsParams.sizeof))
   sg.draw(0, 36, 1)
   sg.endPass()
   sg.commit()

--- a/examples/offscreen.nim
+++ b/examples/offscreen.nim
@@ -67,8 +67,8 @@ proc init() {.cdecl.} =
   var vertices: array[4000, sshape.Vertex]
   var indices: array[24000, uint16]
   var buf = sshape.Buffer(
-    vertices: BufferItem(buffer: sshape.Range(addr: vertices.unsafeAddr, size: vertices.sizeof)),
-    indices: BufferItem(buffer: sshape.Range(addr: indices.unsafeAddr, size: indices.sizeof))
+    vertices: BufferItem(buffer: sshape.Range(addr: vertices.addr, size: vertices.sizeof)),
+    indices: BufferItem(buffer: sshape.Range(addr: indices.addr, size: indices.sizeof))
   )
   buf = sshape.buildTorus(buf, Torus(radius:0.5, ringRadius:0.3, sides:20, rings:36))
   donut = sshape.elementRange(buf)
@@ -155,7 +155,7 @@ proc frame() {.cdecl.} =
   sg.beginPass(offscreenPass, offscreenPassAction)
   sg.applyPipeline(offscreenPip)
   sg.applyBindings(offscreenBindings)
-  sg.applyUniforms(shaderStageVs, shd.slotVsParams, sg.Range(addr: offscreenVsParams.unsafeAddr, size: offscreenVsParams.sizeof))
+  sg.applyUniforms(shaderStageVs, shd.slotVsParams, sg.Range(addr: offscreenVsParams.addr, size: offscreenVsParams.sizeof))
   sg.draw(donut.baseElement, donut.numElements, 1)
   sg.endPass()
 
@@ -167,7 +167,7 @@ proc frame() {.cdecl.} =
   sg.beginDefaultPass(defaultPassAction, sapp.width(), sapp.height())
   sg.applyPipeline(defaultPip)
   sg.applyBindings(defaultBindings)
-  sg.applyUniforms(shaderStageVs, shd.slotVsParams, sg.Range(addr: defaultVsParams.unsafeAddr, size: offscreenVsParams.sizeof))
+  sg.applyUniforms(shaderStageVs, shd.slotVsParams, sg.Range(addr: defaultVsParams.addr, size: offscreenVsParams.sizeof))
   sg.draw(sphere.baseElement, sphere.numElements, 1)
   sg.endPass()
   sg.commit()

--- a/examples/quad.nim
+++ b/examples/quad.nim
@@ -28,14 +28,14 @@ proc init() {.cdecl.} =
     -0.5, -0.5, 0.5,    1.0, 1.0, 0.0, 1.0
   ]
   bindings.vertexBuffers[0] = sg.makeBuffer(BufferDesc(
-    data: sg.Range(addr: vertices.unsafeAddr, size: vertices.sizeof)
+    data: sg.Range(addr: vertices.addr, size: vertices.sizeof)
   ))
 
   # an index buffer
   const indices = [ 0'u16, 1, 2, 0, 2, 3 ]
   bindings.indexBuffer = sg.makeBuffer(BufferDesc(
     type: bufferTypeIndexBuffer,
-    data: sg.Range(addr: indices.unsafeAddr, size: indices.sizeof)
+    data: sg.Range(addr: indices.addr, size: indices.sizeof)
   ))
 
   # a shader and pipeline object

--- a/examples/sgl.nim
+++ b/examples/sgl.nim
@@ -38,7 +38,7 @@ proc init() {.cdecl.} =
     width: imgWidth,
     height: imgHeight,
     data: sg.ImageData(
-      subimage: [ [ sg.Range(addr: pixels.unsafeAddr, size: pixels.sizeof) ] ]
+      subimage: [ [ sg.Range(addr: pixels.addr, size: pixels.sizeof) ] ]
     )
   ))
 

--- a/examples/shaders/blend.nim
+++ b/examples/shaders/blend.nim
@@ -48,14 +48,14 @@ type QuadVsParams* {.packed.} = object
 
 #
 #   #version 330
-#   
+#
 #   layout(location = 0) in vec2 position;
-#   
+#
 #   void main()
 #   {
 #       gl_Position = vec4(position, 0.5, 1.0);
 #   }
-#   
+#
 #
 const vsBgSourceGlsl330: array[116, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x6c,0x61,
@@ -69,17 +69,17 @@ const vsBgSourceGlsl330: array[116, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   uniform vec4 bg_fs_params[1];
 #   layout(location = 0) out vec4 frag_color;
-#   
+#
 #   void main()
 #   {
 #       vec2 _30 = fract((gl_FragCoord.xy - vec2(bg_fs_params[0].x)) * vec2(0.0199999995529651641845703125));
 #       float _41 = _30.x * _30.y;
 #       frag_color = vec4(_41, _41, _41, 1.0);
 #   }
-#   
+#
 #
 const fsBgSourceGlsl330: array[285, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x75,0x6e,
@@ -103,18 +103,18 @@ const fsBgSourceGlsl330: array[285, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   uniform vec4 quad_vs_params[4];
 #   layout(location = 0) in vec4 position;
 #   out vec4 color;
 #   layout(location = 1) in vec4 color0;
-#   
+#
 #   void main()
 #   {
 #       gl_Position = mat4(quad_vs_params[0], quad_vs_params[1], quad_vs_params[2], quad_vs_params[3]) * position;
 #       color = color0;
 #   }
-#   
+#
 #
 const vsQuadSourceGlsl330: array[288, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x75,0x6e,
@@ -139,15 +139,15 @@ const vsQuadSourceGlsl330: array[288, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   layout(location = 0) out vec4 frag_color;
 #   in vec4 color;
-#   
+#
 #   void main()
 #   {
 #       frag_color = color;
 #   }
-#   
+#
 #
 const fsQuadSourceGlsl330: array[114, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x6c,0x61,
@@ -162,24 +162,24 @@ const fsQuadSourceGlsl330: array[114, uint8] = [
 #
 #   static float4 gl_Position;
 #   static float2 position;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float2 position : TEXCOORD0;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 gl_Position : SV_Position;
 #   };
-#   
+#
 #   #line 8 "examples/shaders/blend.glsl"
 #   void vert_main()
 #   {
 #   #line 8 "examples/shaders/blend.glsl"
 #       gl_Position = float4(position, 0.5f, 1.0f);
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       position = stage_input.position;
@@ -231,21 +231,21 @@ const vsBgSourceHlsl4: array[552, uint8] = [
 #   {
 #       float _19_tick : packoffset(c0);
 #   };
-#   
-#   
+#
+#
 #   static float4 gl_FragCoord;
 #   static float4 frag_color;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 gl_FragCoord : SV_Position;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 frag_color : SV_Target0;
 #   };
-#   
+#
 #   #line 13 "examples/shaders/blend.glsl"
 #   void frag_main()
 #   {
@@ -255,7 +255,7 @@ const vsBgSourceHlsl4: array[552, uint8] = [
 #       float _41 = _30.x * _30.y;
 #       frag_color = float4(_41, _41, _41, 1.0f);
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       gl_FragCoord = stage_input.gl_FragCoord;
@@ -327,25 +327,25 @@ const fsBgSourceHlsl4: array[851, uint8] = [
 #   {
 #       row_major float4x4 _21_mvp : packoffset(c0);
 #   };
-#   
-#   
+#
+#
 #   static float4 gl_Position;
 #   static float4 position;
 #   static float4 color;
 #   static float4 color0;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 position : TEXCOORD0;
 #       float4 color0 : TEXCOORD1;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 color : TEXCOORD0;
 #       float4 gl_Position : SV_Position;
 #   };
-#   
+#
 #   #line 16 "examples/shaders/blend.glsl"
 #   void vert_main()
 #   {
@@ -354,7 +354,7 @@ const fsBgSourceHlsl4: array[851, uint8] = [
 #   #line 17 "examples/shaders/blend.glsl"
 #       color = color0;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       position = stage_input.position;
@@ -426,24 +426,24 @@ const vsQuadSourceHlsl4: array[870, uint8] = [
 #
 #   static float4 frag_color;
 #   static float4 color;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 color : TEXCOORD0;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 frag_color : SV_Target0;
 #   };
-#   
+#
 #   #line 9 "examples/shaders/blend.glsl"
 #   void frag_main()
 #   {
 #   #line 9 "examples/shaders/blend.glsl"
 #       frag_color = color;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       color = stage_input.color;
@@ -490,19 +490,19 @@ const fsQuadSourceHlsl4: array[511, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float4 gl_Position [[position]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float2 position [[attribute(0)]];
 #   };
-#   
+#
 #   #line 8 "examples/shaders/blend.glsl"
 #   vertex main0_out main0(main0_in in [[stage_in]])
 #   {
@@ -511,7 +511,7 @@ const fsQuadSourceHlsl4: array[511, uint8] = [
 #       out.gl_Position = float4(in.position, 0.5, 1.0);
 #       return out;
 #   }
-#   
+#
 #
 const vsBgSourceMetalMacos: array[416, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -545,19 +545,19 @@ const vsBgSourceMetalMacos: array[416, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct bg_fs_params
 #   {
 #       float tick;
 #   };
-#   
+#
 #   struct main0_out
 #   {
 #       float4 frag_color [[color(0)]];
 #   };
-#   
+#
 #   #line 13 "examples/shaders/blend.glsl"
 #   fragment main0_out main0(constant bg_fs_params& _19 [[buffer(0)]], float4 gl_FragCoord [[position]])
 #   {
@@ -569,7 +569,7 @@ const vsBgSourceMetalMacos: array[416, uint8] = [
 #       out.frag_color = float4(_41, _41, _41, 1.0);
 #       return out;
 #   }
-#   
+#
 #
 const fsBgSourceMetalMacos: array[620, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -615,26 +615,26 @@ const fsBgSourceMetalMacos: array[620, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct quad_vs_params
 #   {
 #       float4x4 mvp;
 #   };
-#   
+#
 #   struct main0_out
 #   {
 #       float4 color [[user(locn0)]];
 #       float4 gl_Position [[position]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 position [[attribute(0)]];
 #       float4 color0 [[attribute(1)]];
 #   };
-#   
+#
 #   #line 16 "examples/shaders/blend.glsl"
 #   vertex main0_out main0(main0_in in [[stage_in]], constant quad_vs_params& _21 [[buffer(0)]])
 #   {
@@ -645,7 +645,7 @@ const fsBgSourceMetalMacos: array[620, uint8] = [
 #       out.color = in.color0;
 #       return out;
 #   }
-#   
+#
 #
 const vsQuadSourceMetalMacos: array[636, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -692,19 +692,19 @@ const vsQuadSourceMetalMacos: array[636, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float4 frag_color [[color(0)]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 color [[user(locn0)]];
 #   };
-#   
+#
 #   #line 9 "examples/shaders/blend.glsl"
 #   fragment main0_out main0(main0_in in [[stage_in]])
 #   {
@@ -713,7 +713,7 @@ const vsQuadSourceMetalMacos: array[636, uint8] = [
 #       out.frag_color = in.color;
 #       return out;
 #   }
-#   
+#
 #
 const fsQuadSourceMetalMacos: array[391, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -746,9 +746,9 @@ proc bgShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
   case backend:
     of backendGlcore33:
       result.attrs[0].name = "position"
-      result.vs.source = cast[cstring](unsafeAddr(vsBgSourceGlsl330))
+      result.vs.source = cast[cstring](addr(vsBgSourceGlsl330))
       result.vs.entry = "main"
-      result.fs.source = cast[cstring](unsafeAddr(fsBgSourceGlsl330))
+      result.fs.source = cast[cstring](addr(fsBgSourceGlsl330))
       result.fs.entry = "main"
       result.fs.uniformBlocks[0].size = 16
       result.fs.uniformBlocks[0].layout = uniformLayoutStd140
@@ -759,19 +759,19 @@ proc bgShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
     of backendD3d11:
       result.attrs[0].semName = "TEXCOORD"
       result.attrs[0].semIndex = 0
-      result.vs.source = cast[cstring](unsafeAddr(vsBgSourceHlsl4))
+      result.vs.source = cast[cstring](addr(vsBgSourceHlsl4))
       result.vs.d3d11Target = "vs_4_0"
       result.vs.entry = "main"
-      result.fs.source = cast[cstring](unsafeAddr(fsBgSourceHlsl4))
+      result.fs.source = cast[cstring](addr(fsBgSourceHlsl4))
       result.fs.d3d11Target = "ps_4_0"
       result.fs.entry = "main"
       result.fs.uniformBlocks[0].size = 16
       result.fs.uniformBlocks[0].layout = uniformLayoutStd140
       result.label = "bgShader"
     of backendMetalMacos:
-      result.vs.source = cast[cstring](unsafeAddr(vsBgSourceMetalMacos))
+      result.vs.source = cast[cstring](addr(vsBgSourceMetalMacos))
       result.vs.entry = "main0"
-      result.fs.source = cast[cstring](unsafeAddr(fsBgSourceMetalMacos))
+      result.fs.source = cast[cstring](addr(fsBgSourceMetalMacos))
       result.fs.entry = "main0"
       result.fs.uniformBlocks[0].size = 16
       result.fs.uniformBlocks[0].layout = uniformLayoutStd140
@@ -783,14 +783,14 @@ proc quadShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
     of backendGlcore33:
       result.attrs[0].name = "position"
       result.attrs[1].name = "color0"
-      result.vs.source = cast[cstring](unsafeAddr(vsQuadSourceGlsl330))
+      result.vs.source = cast[cstring](addr(vsQuadSourceGlsl330))
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
       result.vs.uniformBlocks[0].uniforms[0].name = "quad_vs_params"
       result.vs.uniformBlocks[0].uniforms[0].type = uniformTypeFloat4
       result.vs.uniformBlocks[0].uniforms[0].arrayCount = 4
-      result.fs.source = cast[cstring](unsafeAddr(fsQuadSourceGlsl330))
+      result.fs.source = cast[cstring](addr(fsQuadSourceGlsl330))
       result.fs.entry = "main"
       result.label = "quadShader"
     of backendD3d11:
@@ -798,21 +798,21 @@ proc quadShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.attrs[0].semIndex = 0
       result.attrs[1].semName = "TEXCOORD"
       result.attrs[1].semIndex = 1
-      result.vs.source = cast[cstring](unsafeAddr(vsQuadSourceHlsl4))
+      result.vs.source = cast[cstring](addr(vsQuadSourceHlsl4))
       result.vs.d3d11Target = "vs_4_0"
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsQuadSourceHlsl4))
+      result.fs.source = cast[cstring](addr(fsQuadSourceHlsl4))
       result.fs.d3d11Target = "ps_4_0"
       result.fs.entry = "main"
       result.label = "quadShader"
     of backendMetalMacos:
-      result.vs.source = cast[cstring](unsafeAddr(vsQuadSourceMetalMacos))
+      result.vs.source = cast[cstring](addr(vsQuadSourceMetalMacos))
       result.vs.entry = "main0"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsQuadSourceMetalMacos))
+      result.fs.source = cast[cstring](addr(fsQuadSourceMetalMacos))
       result.fs.entry = "main0"
       result.label = "quadShader"
     else: discard

--- a/examples/shaders/bufferoffsets.nim
+++ b/examples/shaders/bufferoffsets.nim
@@ -24,17 +24,17 @@ const attrVsColor0* = 1
 
 #
 #   #version 330
-#   
+#
 #   layout(location = 0) in vec4 position;
 #   out vec4 color;
 #   layout(location = 1) in vec4 color0;
-#   
+#
 #   void main()
 #   {
 #       gl_Position = position;
 #       color = color0;
 #   }
-#   
+#
 #
 const vsSourceGlsl330: array[173, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x6c,0x61,
@@ -51,15 +51,15 @@ const vsSourceGlsl330: array[173, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   layout(location = 0) out vec4 frag_color;
 #   in vec4 color;
-#   
+#
 #   void main()
 #   {
 #       frag_color = color;
 #   }
-#   
+#
 #
 const fsSourceGlsl330: array[114, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x6c,0x61,
@@ -76,19 +76,19 @@ const fsSourceGlsl330: array[114, uint8] = [
 #   static float4 position;
 #   static float4 color;
 #   static float4 color0;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 position : TEXCOORD0;
 #       float4 color0 : TEXCOORD1;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 color : TEXCOORD0;
 #       float4 gl_Position : SV_Position;
 #   };
-#   
+#
 #   #line 12 "examples/shaders/bufferoffsets.glsl"
 #   void vert_main()
 #   {
@@ -97,7 +97,7 @@ const fsSourceGlsl330: array[114, uint8] = [
 #   #line 13 "examples/shaders/bufferoffsets.glsl"
 #       color = color0;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       position = stage_input.position;
@@ -164,24 +164,24 @@ const vsSourceHlsl4: array[786, uint8] = [
 #
 #   static float4 frag_color;
 #   static float4 color;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 color : TEXCOORD0;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 frag_color : SV_Target0;
 #   };
-#   
+#
 #   #line 10 "examples/shaders/bufferoffsets.glsl"
 #   void frag_main()
 #   {
 #   #line 10 "examples/shaders/bufferoffsets.glsl"
 #       frag_color = color;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       color = stage_input.color;
@@ -230,21 +230,21 @@ const fsSourceHlsl4: array[529, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float4 color [[user(locn0)]];
 #       float4 gl_Position [[position]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 position [[attribute(0)]];
 #       float4 color0 [[attribute(1)]];
 #   };
-#   
+#
 #   #line 12 "examples/shaders/bufferoffsets.glsl"
 #   vertex main0_out main0(main0_in in [[stage_in]])
 #   {
@@ -255,7 +255,7 @@ const fsSourceHlsl4: array[529, uint8] = [
 #       out.color = in.color0;
 #       return out;
 #   }
-#   
+#
 #
 const vsSourceMetalMacos: array[560, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -298,19 +298,19 @@ const vsSourceMetalMacos: array[560, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float4 frag_color [[color(0)]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 color [[user(locn0)]];
 #   };
-#   
+#
 #   #line 10 "examples/shaders/bufferoffsets.glsl"
 #   fragment main0_out main0(main0_in in [[stage_in]])
 #   {
@@ -319,7 +319,7 @@ const vsSourceMetalMacos: array[560, uint8] = [
 #       out.frag_color = in.color;
 #       return out;
 #   }
-#   
+#
 #
 const fsSourceMetalMacos: array[409, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -354,9 +354,9 @@ proc bufferoffsetsShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
     of backendGlcore33:
       result.attrs[0].name = "position"
       result.attrs[1].name = "color0"
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceGlsl330))
+      result.vs.source = cast[cstring](addr(vsSourceGlsl330))
       result.vs.entry = "main"
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceGlsl330))
+      result.fs.source = cast[cstring](addr(fsSourceGlsl330))
       result.fs.entry = "main"
       result.label = "bufferoffsetsShader"
     of backendD3d11:
@@ -364,17 +364,17 @@ proc bufferoffsetsShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.attrs[0].semIndex = 0
       result.attrs[1].semName = "TEXCOORD"
       result.attrs[1].semIndex = 1
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceHlsl4))
+      result.vs.source = cast[cstring](addr(vsSourceHlsl4))
       result.vs.d3d11Target = "vs_4_0"
       result.vs.entry = "main"
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceHlsl4))
+      result.fs.source = cast[cstring](addr(fsSourceHlsl4))
       result.fs.d3d11Target = "ps_4_0"
       result.fs.entry = "main"
       result.label = "bufferoffsetsShader"
     of backendMetalMacos:
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceMetalMacos))
+      result.vs.source = cast[cstring](addr(vsSourceMetalMacos))
       result.vs.entry = "main0"
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceMetalMacos))
+      result.fs.source = cast[cstring](addr(fsSourceMetalMacos))
       result.fs.entry = "main0"
       result.label = "bufferoffsetsShader"
     else: discard

--- a/examples/shaders/cube.nim
+++ b/examples/shaders/cube.nim
@@ -32,18 +32,18 @@ type VsParams* {.packed.} = object
 
 #
 #   #version 330
-#   
+#
 #   uniform vec4 vs_params[4];
 #   layout(location = 0) in vec4 position;
 #   out vec4 color;
 #   layout(location = 1) in vec4 color0;
-#   
+#
 #   void main()
 #   {
 #       gl_Position = mat4(vs_params[0], vs_params[1], vs_params[2], vs_params[3]) * position;
 #       color = color0;
 #   }
-#   
+#
 #
 const vsSourceGlsl330: array[263, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x75,0x6e,
@@ -66,15 +66,15 @@ const vsSourceGlsl330: array[263, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   layout(location = 0) out vec4 frag_color;
 #   in vec4 color;
-#   
+#
 #   void main()
 #   {
 #       frag_color = color;
 #   }
-#   
+#
 #
 const fsSourceGlsl330: array[114, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x6c,0x61,
@@ -91,25 +91,25 @@ const fsSourceGlsl330: array[114, uint8] = [
 #   {
 #       row_major float4x4 _21_mvp : packoffset(c0);
 #   };
-#   
-#   
+#
+#
 #   static float4 gl_Position;
 #   static float4 position;
 #   static float4 color;
 #   static float4 color0;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 position : TEXCOORD0;
 #       float4 color0 : TEXCOORD1;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 color : TEXCOORD0;
 #       float4 gl_Position : SV_Position;
 #   };
-#   
+#
 #   #line 16 "examples/shaders/cube.glsl"
 #   void vert_main()
 #   {
@@ -118,7 +118,7 @@ const fsSourceGlsl330: array[114, uint8] = [
 #   #line 17 "examples/shaders/cube.glsl"
 #       color = color0;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       position = stage_input.position;
@@ -189,24 +189,24 @@ const vsSourceHlsl4: array[862, uint8] = [
 #
 #   static float4 frag_color;
 #   static float4 color;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 color : TEXCOORD0;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 frag_color : SV_Target0;
 #   };
-#   
+#
 #   #line 10 "examples/shaders/cube.glsl"
 #   void frag_main()
 #   {
 #   #line 10 "examples/shaders/cube.glsl"
 #       frag_color = color;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       color = stage_input.color;
@@ -253,26 +253,26 @@ const fsSourceHlsl4: array[511, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct vs_params
 #   {
 #       float4x4 mvp;
 #   };
-#   
+#
 #   struct main0_out
 #   {
 #       float4 color [[user(locn0)]];
 #       float4 gl_Position [[position]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 position [[attribute(0)]];
 #       float4 color0 [[attribute(1)]];
 #   };
-#   
+#
 #   #line 16 "examples/shaders/cube.glsl"
 #   vertex main0_out main0(main0_in in [[stage_in]], constant vs_params& _21 [[buffer(0)]])
 #   {
@@ -283,7 +283,7 @@ const fsSourceHlsl4: array[511, uint8] = [
 #       out.color = in.color0;
 #       return out;
 #   }
-#   
+#
 #
 const vsSourceMetalMacos: array[623, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -329,19 +329,19 @@ const vsSourceMetalMacos: array[623, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float4 frag_color [[color(0)]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 color [[user(locn0)]];
 #   };
-#   
+#
 #   #line 10 "examples/shaders/cube.glsl"
 #   fragment main0_out main0(main0_in in [[stage_in]])
 #   {
@@ -350,7 +350,7 @@ const vsSourceMetalMacos: array[623, uint8] = [
 #       out.frag_color = in.color;
 #       return out;
 #   }
-#   
+#
 #
 const fsSourceMetalMacos: array[391, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -384,14 +384,14 @@ proc cubeShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
     of backendGlcore33:
       result.attrs[0].name = "position"
       result.attrs[1].name = "color0"
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceGlsl330))
+      result.vs.source = cast[cstring](addr(vsSourceGlsl330))
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
       result.vs.uniformBlocks[0].uniforms[0].name = "vs_params"
       result.vs.uniformBlocks[0].uniforms[0].type = uniformTypeFloat4
       result.vs.uniformBlocks[0].uniforms[0].arrayCount = 4
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceGlsl330))
+      result.fs.source = cast[cstring](addr(fsSourceGlsl330))
       result.fs.entry = "main"
       result.label = "cubeShader"
     of backendD3d11:
@@ -399,21 +399,21 @@ proc cubeShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.attrs[0].semIndex = 0
       result.attrs[1].semName = "TEXCOORD"
       result.attrs[1].semIndex = 1
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceHlsl4))
+      result.vs.source = cast[cstring](addr(vsSourceHlsl4))
       result.vs.d3d11Target = "vs_4_0"
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceHlsl4))
+      result.fs.source = cast[cstring](addr(fsSourceHlsl4))
       result.fs.d3d11Target = "ps_4_0"
       result.fs.entry = "main"
       result.label = "cubeShader"
     of backendMetalMacos:
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceMetalMacos))
+      result.vs.source = cast[cstring](addr(vsSourceMetalMacos))
       result.vs.entry = "main0"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceMetalMacos))
+      result.fs.source = cast[cstring](addr(fsSourceMetalMacos))
       result.fs.entry = "main0"
       result.label = "cubeShader"
     else: discard

--- a/examples/shaders/instancing.nim
+++ b/examples/shaders/instancing.nim
@@ -34,19 +34,19 @@ type VsParams* {.packed.} = object
 
 #
 #   #version 330
-#   
+#
 #   uniform vec4 vs_params[4];
 #   layout(location = 0) in vec3 pos;
 #   layout(location = 2) in vec3 inst_pos;
 #   out vec4 color;
 #   layout(location = 1) in vec4 color0;
-#   
+#
 #   void main()
 #   {
 #       gl_Position = mat4(vs_params[0], vs_params[1], vs_params[2], vs_params[3]) * vec4(pos + inst_pos, 1.0);
 #       color = color0;
 #   }
-#   
+#
 #
 const vsSourceGlsl330: array[314, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x75,0x6e,
@@ -72,15 +72,15 @@ const vsSourceGlsl330: array[314, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   layout(location = 0) out vec4 frag_color;
 #   in vec4 color;
-#   
+#
 #   void main()
 #   {
 #       frag_color = color;
 #   }
-#   
+#
 #
 const fsSourceGlsl330: array[114, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x6c,0x61,
@@ -97,27 +97,27 @@ const fsSourceGlsl330: array[114, uint8] = [
 #   {
 #       row_major float4x4 _35_mvp : packoffset(c0);
 #   };
-#   
-#   
+#
+#
 #   static float4 gl_Position;
 #   static float3 pos;
 #   static float3 inst_pos;
 #   static float4 color;
 #   static float4 color0;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float3 pos : TEXCOORD0;
 #       float4 color0 : TEXCOORD1;
 #       float3 inst_pos : TEXCOORD2;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 color : TEXCOORD0;
 #       float4 gl_Position : SV_Position;
 #   };
-#   
+#
 #   #line 17 "examples/shaders/instancing.glsl"
 #   void vert_main()
 #   {
@@ -127,7 +127,7 @@ const fsSourceGlsl330: array[114, uint8] = [
 #   #line 19 "examples/shaders/instancing.glsl"
 #       color = color0;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       pos = stage_input.pos;
@@ -209,24 +209,24 @@ const vsSourceHlsl4: array[1018, uint8] = [
 #
 #   static float4 frag_color;
 #   static float4 color;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 color : TEXCOORD0;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 frag_color : SV_Target0;
 #   };
-#   
+#
 #   #line 9 "examples/shaders/instancing.glsl"
 #   void frag_main()
 #   {
 #   #line 9 "examples/shaders/instancing.glsl"
 #       frag_color = color;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       color = stage_input.color;
@@ -274,27 +274,27 @@ const fsSourceHlsl4: array[521, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct vs_params
 #   {
 #       float4x4 mvp;
 #   };
-#   
+#
 #   struct main0_out
 #   {
 #       float4 color [[user(locn0)]];
 #       float4 gl_Position [[position]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float3 pos [[attribute(0)]];
 #       float4 color0 [[attribute(1)]];
 #       float3 inst_pos [[attribute(2)]];
 #   };
-#   
+#
 #   #line 17 "examples/shaders/instancing.glsl"
 #   vertex main0_out main0(main0_in in [[stage_in]], constant vs_params& _35 [[buffer(0)]])
 #   {
@@ -306,7 +306,7 @@ const fsSourceHlsl4: array[521, uint8] = [
 #       out.color = in.color0;
 #       return out;
 #   }
-#   
+#
 #
 const vsSourceMetalMacos: array[740, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -360,19 +360,19 @@ const vsSourceMetalMacos: array[740, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float4 frag_color [[color(0)]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 color [[user(locn0)]];
 #   };
-#   
+#
 #   #line 9 "examples/shaders/instancing.glsl"
 #   fragment main0_out main0(main0_in in [[stage_in]])
 #   {
@@ -381,7 +381,7 @@ const vsSourceMetalMacos: array[740, uint8] = [
 #       out.frag_color = in.color;
 #       return out;
 #   }
-#   
+#
 #
 const fsSourceMetalMacos: array[401, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -417,14 +417,14 @@ proc instancingShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.attrs[0].name = "pos"
       result.attrs[1].name = "color0"
       result.attrs[2].name = "inst_pos"
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceGlsl330))
+      result.vs.source = cast[cstring](addr(vsSourceGlsl330))
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
       result.vs.uniformBlocks[0].uniforms[0].name = "vs_params"
       result.vs.uniformBlocks[0].uniforms[0].type = uniformTypeFloat4
       result.vs.uniformBlocks[0].uniforms[0].arrayCount = 4
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceGlsl330))
+      result.fs.source = cast[cstring](addr(fsSourceGlsl330))
       result.fs.entry = "main"
       result.label = "instancingShader"
     of backendD3d11:
@@ -434,21 +434,21 @@ proc instancingShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.attrs[1].semIndex = 1
       result.attrs[2].semName = "TEXCOORD"
       result.attrs[2].semIndex = 2
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceHlsl4))
+      result.vs.source = cast[cstring](addr(vsSourceHlsl4))
       result.vs.d3d11Target = "vs_4_0"
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceHlsl4))
+      result.fs.source = cast[cstring](addr(fsSourceHlsl4))
       result.fs.d3d11Target = "ps_4_0"
       result.fs.entry = "main"
       result.label = "instancingShader"
     of backendMetalMacos:
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceMetalMacos))
+      result.vs.source = cast[cstring](addr(vsSourceMetalMacos))
       result.vs.entry = "main0"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceMetalMacos))
+      result.fs.source = cast[cstring](addr(fsSourceMetalMacos))
       result.fs.entry = "main0"
       result.label = "instancingShader"
     else: discard

--- a/examples/shaders/mrt.nim
+++ b/examples/shaders/mrt.nim
@@ -77,18 +77,18 @@ type FsqParams* {.packed.} = object
 
 #
 #   #version 330
-#   
+#
 #   uniform vec4 offscreen_params[4];
 #   layout(location = 0) in vec4 pos;
 #   out float bright;
 #   layout(location = 1) in float bright0;
-#   
+#
 #   void main()
 #   {
 #       gl_Position = mat4(offscreen_params[0], offscreen_params[1], offscreen_params[2], offscreen_params[3]) * pos;
 #       bright = bright0;
 #   }
-#   
+#
 #
 const vsOffscreenSourceGlsl330: array[294, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x75,0x6e,
@@ -113,19 +113,19 @@ const vsOffscreenSourceGlsl330: array[294, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   layout(location = 0) out vec4 frag_color_0;
 #   in float bright;
 #   layout(location = 1) out vec4 frag_color_1;
 #   layout(location = 2) out vec4 frag_color_2;
-#   
+#
 #   void main()
 #   {
 #       frag_color_0 = vec4(bright, 0.0, 0.0, 1.0);
 #       frag_color_1 = vec4(0.0, bright, 0.0, 1.0);
 #       frag_color_2 = vec4(0.0, 0.0, bright, 1.0);
 #   }
-#   
+#
 #
 const fsOffscreenSourceGlsl330: array[326, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x6c,0x61,
@@ -152,13 +152,13 @@ const fsOffscreenSourceGlsl330: array[326, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   uniform vec4 fsq_params[1];
 #   layout(location = 0) in vec2 pos;
 #   out vec2 uv0;
 #   out vec2 uv1;
 #   out vec2 uv2;
-#   
+#
 #   void main()
 #   {
 #       gl_Position = vec4((pos * 2.0) - vec2(1.0), 0.5, 1.0);
@@ -167,7 +167,7 @@ const fsOffscreenSourceGlsl330: array[326, uint8] = [
 #       uv2 = pos;
 #       gl_Position.y = -gl_Position.y;
 #   }
-#   
+#
 #
 const vsFsqSourceGlsl330: array[335, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x75,0x6e,
@@ -194,21 +194,21 @@ const vsFsqSourceGlsl330: array[335, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   uniform sampler2D tex0;
 #   uniform sampler2D tex1;
 #   uniform sampler2D tex2;
-#   
+#
 #   in vec2 uv0;
 #   in vec2 uv1;
 #   in vec2 uv2;
 #   layout(location = 0) out vec4 frag_color;
-#   
+#
 #   void main()
 #   {
 #       frag_color = vec4((texture(tex0, uv0).xyz + texture(tex1, uv1).xyz) + texture(tex2, uv2).xyz, 1.0);
 #   }
-#   
+#
 #
 const fsFsqSourceGlsl330: array[291, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x75,0x6e,
@@ -233,17 +233,17 @@ const fsFsqSourceGlsl330: array[291, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   layout(location = 0) in vec2 pos;
 #   out vec2 uv;
-#   
+#
 #   void main()
 #   {
 #       gl_Position = vec4((pos * 2.0) - vec2(1.0), 0.5, 1.0);
 #       uv = pos;
 #       gl_Position.y = -gl_Position.y;
 #   }
-#   
+#
 #
 const vsDbgSourceGlsl330: array[189, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x6c,0x61,
@@ -261,17 +261,17 @@ const vsDbgSourceGlsl330: array[189, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   uniform sampler2D tex;
-#   
+#
 #   layout(location = 0) out vec4 frag_color;
 #   in vec2 uv;
-#   
+#
 #   void main()
 #   {
 #       frag_color = vec4(texture(tex, uv).xyz, 1.0);
 #   }
-#   
+#
 #
 const fsDbgSourceGlsl330: array[161, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x75,0x6e,
@@ -291,25 +291,25 @@ const fsDbgSourceGlsl330: array[161, uint8] = [
 #   {
 #       row_major float4x4 _21_mvp : packoffset(c0);
 #   };
-#   
-#   
+#
+#
 #   static float4 gl_Position;
 #   static float4 pos;
 #   static float bright;
 #   static float bright0;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 pos : TEXCOORD0;
 #       float bright0 : TEXCOORD1;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float bright : TEXCOORD0;
 #       float4 gl_Position : SV_Position;
 #   };
-#   
+#
 #   #line 17 "examples/shaders/mrt.glsl"
 #   void vert_main()
 #   {
@@ -318,7 +318,7 @@ const fsDbgSourceGlsl330: array[161, uint8] = [
 #   #line 18 "examples/shaders/mrt.glsl"
 #       bright = bright0;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       pos = stage_input.pos;
@@ -390,19 +390,19 @@ const vsOffscreenSourceHlsl4: array[847, uint8] = [
 #   static float bright;
 #   static float4 frag_color_1;
 #   static float4 frag_color_2;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float bright : TEXCOORD0;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 frag_color_0 : SV_Target0;
 #       float4 frag_color_1 : SV_Target1;
 #       float4 frag_color_2 : SV_Target2;
 #   };
-#   
+#
 #   #line 13 "examples/shaders/mrt.glsl"
 #   void frag_main()
 #   {
@@ -413,7 +413,7 @@ const vsOffscreenSourceHlsl4: array[847, uint8] = [
 #   #line 15 "examples/shaders/mrt.glsl"
 #       frag_color_2 = float4(0.0f, 0.0f, bright, 1.0f);
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       bright = stage_input.bright;
@@ -492,19 +492,19 @@ const fsOffscreenSourceHlsl4: array[952, uint8] = [
 #   {
 #       float2 _38_offset : packoffset(c0);
 #   };
-#   
-#   
+#
+#
 #   static float4 gl_Position;
 #   static float2 pos;
 #   static float2 uv0;
 #   static float2 uv1;
 #   static float2 uv2;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float2 pos : TEXCOORD0;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float2 uv0 : TEXCOORD0;
@@ -512,7 +512,7 @@ const fsOffscreenSourceHlsl4: array[952, uint8] = [
 #       float2 uv2 : TEXCOORD2;
 #       float4 gl_Position : SV_Position;
 #   };
-#   
+#
 #   #line 18 "examples/shaders/mrt.glsl"
 #   void vert_main()
 #   {
@@ -525,7 +525,7 @@ const fsOffscreenSourceHlsl4: array[952, uint8] = [
 #   #line 21 "examples/shaders/mrt.glsl"
 #       uv2 = pos;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       pos = stage_input.pos;
@@ -614,24 +614,24 @@ const vsFsqSourceHlsl4: array[1064, uint8] = [
 #   SamplerState _tex1_sampler : register(s1);
 #   Texture2D<float4> tex2 : register(t2);
 #   SamplerState _tex2_sampler : register(s2);
-#   
+#
 #   static float2 uv0;
 #   static float2 uv1;
 #   static float2 uv2;
 #   static float4 frag_color;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float2 uv0 : TEXCOORD0;
 #       float2 uv1 : TEXCOORD1;
 #       float2 uv2 : TEXCOORD2;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 frag_color : SV_Target0;
 #   };
-#   
+#
 #   #line 17 "examples/shaders/mrt.glsl"
 #   void frag_main()
 #   {
@@ -641,7 +641,7 @@ const vsFsqSourceHlsl4: array[1064, uint8] = [
 #   #line 20 "examples/shaders/mrt.glsl"
 #       frag_color = float4((tex0.Sample(_tex0_sampler, uv0).xyz + tex1.Sample(_tex1_sampler, uv1).xyz) + tex2.Sample(_tex2_sampler, uv2).xyz, 1.0f);
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       uv0 = stage_input.uv0;
@@ -730,18 +730,18 @@ const fsFsqSourceHlsl4: array[1129, uint8] = [
 #   static float4 gl_Position;
 #   static float2 pos;
 #   static float2 uv;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float2 pos : TEXCOORD0;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float2 uv : TEXCOORD0;
 #       float4 gl_Position : SV_Position;
 #   };
-#   
+#
 #   #line 11 "examples/shaders/mrt.glsl"
 #   void vert_main()
 #   {
@@ -750,7 +750,7 @@ const fsFsqSourceHlsl4: array[1129, uint8] = [
 #   #line 12 "examples/shaders/mrt.glsl"
 #       uv = pos;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       pos = stage_input.pos;
@@ -808,27 +808,27 @@ const vsDbgSourceHlsl4: array[666, uint8] = [
 #
 #   Texture2D<float4> tex : register(t0);
 #   SamplerState _tex_sampler : register(s0);
-#   
+#
 #   static float4 frag_color;
 #   static float2 uv;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float2 uv : TEXCOORD0;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 frag_color : SV_Target0;
 #   };
-#   
+#
 #   #line 12 "examples/shaders/mrt.glsl"
 #   void frag_main()
 #   {
 #   #line 12 "examples/shaders/mrt.glsl"
 #       frag_color = float4(tex.Sample(_tex_sampler, uv).xyz, 1.0f);
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       uv = stage_input.uv;
@@ -882,26 +882,26 @@ const fsDbgSourceHlsl4: array[619, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct offscreen_params
 #   {
 #       float4x4 mvp;
 #   };
-#   
+#
 #   struct main0_out
 #   {
 #       float bright [[user(locn0)]];
 #       float4 gl_Position [[position]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 pos [[attribute(0)]];
 #       float bright0 [[attribute(1)]];
 #   };
-#   
+#
 #   #line 17 "examples/shaders/mrt.glsl"
 #   vertex main0_out main0(main0_in in [[stage_in]], constant offscreen_params& _21 [[buffer(0)]])
 #   {
@@ -912,7 +912,7 @@ const fsDbgSourceHlsl4: array[619, uint8] = [
 #       out.bright = in.bright0;
 #       return out;
 #   }
-#   
+#
 #
 const vsOffscreenSourceMetalMacos: array[626, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -959,21 +959,21 @@ const vsOffscreenSourceMetalMacos: array[626, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float4 frag_color_0 [[color(0)]];
 #       float4 frag_color_1 [[color(1)]];
 #       float4 frag_color_2 [[color(2)]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float bright [[user(locn0)]];
 #   };
-#   
+#
 #   #line 13 "examples/shaders/mrt.glsl"
 #   fragment main0_out main0(main0_in in [[stage_in]])
 #   {
@@ -986,7 +986,7 @@ const vsOffscreenSourceMetalMacos: array[626, uint8] = [
 #       out.frag_color_2 = float4(0.0, 0.0, in.bright, 1.0);
 #       return out;
 #   }
-#   
+#
 #
 const fsOffscreenSourceMetalMacos: array[681, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -1036,14 +1036,14 @@ const fsOffscreenSourceMetalMacos: array[681, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct fsq_params
 #   {
 #       float2 offset;
 #   };
-#   
+#
 #   struct main0_out
 #   {
 #       float2 uv0 [[user(locn0)]];
@@ -1051,12 +1051,12 @@ const fsOffscreenSourceMetalMacos: array[681, uint8] = [
 #       float2 uv2 [[user(locn2)]];
 #       float4 gl_Position [[position]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float2 pos [[attribute(0)]];
 #   };
-#   
+#
 #   #line 18 "examples/shaders/mrt.glsl"
 #   vertex main0_out main0(main0_in in [[stage_in]], constant fsq_params& _38 [[buffer(0)]])
 #   {
@@ -1071,7 +1071,7 @@ const fsOffscreenSourceMetalMacos: array[681, uint8] = [
 #       out.uv2 = in.pos;
 #       return out;
 #   }
-#   
+#
 #
 const vsFsqSourceMetalMacos: array[838, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -1131,21 +1131,21 @@ const vsFsqSourceMetalMacos: array[838, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float4 frag_color [[color(0)]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float2 uv0 [[user(locn0)]];
 #       float2 uv1 [[user(locn1)]];
 #       float2 uv2 [[user(locn2)]];
 #   };
-#   
+#
 #   #line 17 "examples/shaders/mrt.glsl"
 #   fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> tex0 [[texture(0)]], texture2d<float> tex1 [[texture(1)]], texture2d<float> tex2 [[texture(2)]], sampler tex0Smplr [[sampler(0)]], sampler tex1Smplr [[sampler(1)]], sampler tex2Smplr [[sampler(2)]])
 #   {
@@ -1157,7 +1157,7 @@ const vsFsqSourceMetalMacos: array[838, uint8] = [
 #       out.frag_color = float4((tex0.sample(tex0Smplr, in.uv0).xyz + tex1.sample(tex1Smplr, in.uv1).xyz) + tex2.sample(tex2Smplr, in.uv2).xyz, 1.0);
 #       return out;
 #   }
-#   
+#
 #
 const fsFsqSourceMetalMacos: array[893, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -1220,20 +1220,20 @@ const fsFsqSourceMetalMacos: array[893, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float2 uv [[user(locn0)]];
 #       float4 gl_Position [[position]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float2 pos [[attribute(0)]];
 #   };
-#   
+#
 #   #line 11 "examples/shaders/mrt.glsl"
 #   vertex main0_out main0(main0_in in [[stage_in]])
 #   {
@@ -1244,7 +1244,7 @@ const fsFsqSourceMetalMacos: array[893, uint8] = [
 #       out.uv = in.pos;
 #       return out;
 #   }
-#   
+#
 #
 const vsDbgSourceMetalMacos: array[515, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -1284,19 +1284,19 @@ const vsDbgSourceMetalMacos: array[515, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float4 frag_color [[color(0)]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float2 uv [[user(locn0)]];
 #   };
-#   
+#
 #   #line 12 "examples/shaders/mrt.glsl"
 #   fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> tex [[texture(0)]], sampler texSmplr [[sampler(0)]])
 #   {
@@ -1305,7 +1305,7 @@ const vsDbgSourceMetalMacos: array[515, uint8] = [
 #       out.frag_color = float4(tex.sample(texSmplr, in.uv).xyz, 1.0);
 #       return out;
 #   }
-#   
+#
 #
 const fsDbgSourceMetalMacos: array[492, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -1344,9 +1344,9 @@ proc dbgShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
   case backend:
     of backendGlcore33:
       result.attrs[0].name = "pos"
-      result.vs.source = cast[cstring](unsafeAddr(vsDbgSourceGlsl330))
+      result.vs.source = cast[cstring](addr(vsDbgSourceGlsl330))
       result.vs.entry = "main"
-      result.fs.source = cast[cstring](unsafeAddr(fsDbgSourceGlsl330))
+      result.fs.source = cast[cstring](addr(fsDbgSourceGlsl330))
       result.fs.entry = "main"
       result.fs.images[0].name = "tex"
       result.fs.images[0].imageType = imageType2d
@@ -1355,10 +1355,10 @@ proc dbgShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
     of backendD3d11:
       result.attrs[0].semName = "TEXCOORD"
       result.attrs[0].semIndex = 0
-      result.vs.source = cast[cstring](unsafeAddr(vsDbgSourceHlsl4))
+      result.vs.source = cast[cstring](addr(vsDbgSourceHlsl4))
       result.vs.d3d11Target = "vs_4_0"
       result.vs.entry = "main"
-      result.fs.source = cast[cstring](unsafeAddr(fsDbgSourceHlsl4))
+      result.fs.source = cast[cstring](addr(fsDbgSourceHlsl4))
       result.fs.d3d11Target = "ps_4_0"
       result.fs.entry = "main"
       result.fs.images[0].name = "tex"
@@ -1366,9 +1366,9 @@ proc dbgShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.fs.images[0].samplerType = samplerTypeFloat
       result.label = "dbgShader"
     of backendMetalMacos:
-      result.vs.source = cast[cstring](unsafeAddr(vsDbgSourceMetalMacos))
+      result.vs.source = cast[cstring](addr(vsDbgSourceMetalMacos))
       result.vs.entry = "main0"
-      result.fs.source = cast[cstring](unsafeAddr(fsDbgSourceMetalMacos))
+      result.fs.source = cast[cstring](addr(fsDbgSourceMetalMacos))
       result.fs.entry = "main0"
       result.fs.images[0].name = "tex"
       result.fs.images[0].imageType = imageType2d
@@ -1380,14 +1380,14 @@ proc fsqShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
   case backend:
     of backendGlcore33:
       result.attrs[0].name = "pos"
-      result.vs.source = cast[cstring](unsafeAddr(vsFsqSourceGlsl330))
+      result.vs.source = cast[cstring](addr(vsFsqSourceGlsl330))
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 16
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
       result.vs.uniformBlocks[0].uniforms[0].name = "fsq_params"
       result.vs.uniformBlocks[0].uniforms[0].type = uniformTypeFloat4
       result.vs.uniformBlocks[0].uniforms[0].arrayCount = 1
-      result.fs.source = cast[cstring](unsafeAddr(fsFsqSourceGlsl330))
+      result.fs.source = cast[cstring](addr(fsFsqSourceGlsl330))
       result.fs.entry = "main"
       result.fs.images[0].name = "tex0"
       result.fs.images[0].imageType = imageType2d
@@ -1402,12 +1402,12 @@ proc fsqShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
     of backendD3d11:
       result.attrs[0].semName = "TEXCOORD"
       result.attrs[0].semIndex = 0
-      result.vs.source = cast[cstring](unsafeAddr(vsFsqSourceHlsl4))
+      result.vs.source = cast[cstring](addr(vsFsqSourceHlsl4))
       result.vs.d3d11Target = "vs_4_0"
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 16
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsFsqSourceHlsl4))
+      result.fs.source = cast[cstring](addr(fsFsqSourceHlsl4))
       result.fs.d3d11Target = "ps_4_0"
       result.fs.entry = "main"
       result.fs.images[0].name = "tex0"
@@ -1421,11 +1421,11 @@ proc fsqShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.fs.images[2].samplerType = samplerTypeFloat
       result.label = "fsqShader"
     of backendMetalMacos:
-      result.vs.source = cast[cstring](unsafeAddr(vsFsqSourceMetalMacos))
+      result.vs.source = cast[cstring](addr(vsFsqSourceMetalMacos))
       result.vs.entry = "main0"
       result.vs.uniformBlocks[0].size = 16
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsFsqSourceMetalMacos))
+      result.fs.source = cast[cstring](addr(fsFsqSourceMetalMacos))
       result.fs.entry = "main0"
       result.fs.images[0].name = "tex0"
       result.fs.images[0].imageType = imageType2d
@@ -1444,14 +1444,14 @@ proc offscreenShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
     of backendGlcore33:
       result.attrs[0].name = "pos"
       result.attrs[1].name = "bright0"
-      result.vs.source = cast[cstring](unsafeAddr(vsOffscreenSourceGlsl330))
+      result.vs.source = cast[cstring](addr(vsOffscreenSourceGlsl330))
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
       result.vs.uniformBlocks[0].uniforms[0].name = "offscreen_params"
       result.vs.uniformBlocks[0].uniforms[0].type = uniformTypeFloat4
       result.vs.uniformBlocks[0].uniforms[0].arrayCount = 4
-      result.fs.source = cast[cstring](unsafeAddr(fsOffscreenSourceGlsl330))
+      result.fs.source = cast[cstring](addr(fsOffscreenSourceGlsl330))
       result.fs.entry = "main"
       result.label = "offscreenShader"
     of backendD3d11:
@@ -1459,21 +1459,21 @@ proc offscreenShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.attrs[0].semIndex = 0
       result.attrs[1].semName = "TEXCOORD"
       result.attrs[1].semIndex = 1
-      result.vs.source = cast[cstring](unsafeAddr(vsOffscreenSourceHlsl4))
+      result.vs.source = cast[cstring](addr(vsOffscreenSourceHlsl4))
       result.vs.d3d11Target = "vs_4_0"
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsOffscreenSourceHlsl4))
+      result.fs.source = cast[cstring](addr(fsOffscreenSourceHlsl4))
       result.fs.d3d11Target = "ps_4_0"
       result.fs.entry = "main"
       result.label = "offscreenShader"
     of backendMetalMacos:
-      result.vs.source = cast[cstring](unsafeAddr(vsOffscreenSourceMetalMacos))
+      result.vs.source = cast[cstring](addr(vsOffscreenSourceMetalMacos))
       result.vs.entry = "main0"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsOffscreenSourceMetalMacos))
+      result.fs.source = cast[cstring](addr(fsOffscreenSourceMetalMacos))
       result.fs.entry = "main0"
       result.label = "offscreenShader"
     else: discard

--- a/examples/shaders/noninterleaved.nim
+++ b/examples/shaders/noninterleaved.nim
@@ -32,18 +32,18 @@ type VsParams* {.packed.} = object
 
 #
 #   #version 330
-#   
+#
 #   uniform vec4 vs_params[4];
 #   layout(location = 0) in vec4 position;
 #   out vec4 color;
 #   layout(location = 1) in vec4 color0;
-#   
+#
 #   void main()
 #   {
 #       gl_Position = mat4(vs_params[0], vs_params[1], vs_params[2], vs_params[3]) * position;
 #       color = color0;
 #   }
-#   
+#
 #
 const vsSourceGlsl330: array[263, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x75,0x6e,
@@ -66,15 +66,15 @@ const vsSourceGlsl330: array[263, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   layout(location = 0) out vec4 frag_color;
 #   in vec4 color;
-#   
+#
 #   void main()
 #   {
 #       frag_color = color;
 #   }
-#   
+#
 #
 const fsSourceGlsl330: array[114, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x6c,0x61,
@@ -91,25 +91,25 @@ const fsSourceGlsl330: array[114, uint8] = [
 #   {
 #       row_major float4x4 _21_mvp : packoffset(c0);
 #   };
-#   
-#   
+#
+#
 #   static float4 gl_Position;
 #   static float4 position;
 #   static float4 color;
 #   static float4 color0;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 position : TEXCOORD0;
 #       float4 color0 : TEXCOORD1;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 color : TEXCOORD0;
 #       float4 gl_Position : SV_Position;
 #   };
-#   
+#
 #   #line 15 "examples/shaders/noninterleaved.glsl"
 #   void vert_main()
 #   {
@@ -118,7 +118,7 @@ const fsSourceGlsl330: array[114, uint8] = [
 #   #line 16 "examples/shaders/noninterleaved.glsl"
 #       color = color0;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       position = stage_input.position;
@@ -191,24 +191,24 @@ const vsSourceHlsl4: array[892, uint8] = [
 #
 #   static float4 frag_color;
 #   static float4 color;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 color : TEXCOORD0;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 frag_color : SV_Target0;
 #   };
-#   
+#
 #   #line 10 "examples/shaders/noninterleaved.glsl"
 #   void frag_main()
 #   {
 #   #line 10 "examples/shaders/noninterleaved.glsl"
 #       frag_color = color;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       color = stage_input.color;
@@ -257,26 +257,26 @@ const fsSourceHlsl4: array[531, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct vs_params
 #   {
 #       float4x4 mvp;
 #   };
-#   
+#
 #   struct main0_out
 #   {
 #       float4 color [[user(locn0)]];
 #       float4 gl_Position [[position]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 position [[attribute(0)]];
 #       float4 color0 [[attribute(1)]];
 #   };
-#   
+#
 #   #line 15 "examples/shaders/noninterleaved.glsl"
 #   vertex main0_out main0(main0_in in [[stage_in]], constant vs_params& _21 [[buffer(0)]])
 #   {
@@ -287,7 +287,7 @@ const fsSourceHlsl4: array[531, uint8] = [
 #       out.color = in.color0;
 #       return out;
 #   }
-#   
+#
 #
 const vsSourceMetalMacos: array[653, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -335,19 +335,19 @@ const vsSourceMetalMacos: array[653, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float4 frag_color [[color(0)]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 color [[user(locn0)]];
 #   };
-#   
+#
 #   #line 10 "examples/shaders/noninterleaved.glsl"
 #   fragment main0_out main0(main0_in in [[stage_in]])
 #   {
@@ -356,7 +356,7 @@ const vsSourceMetalMacos: array[653, uint8] = [
 #       out.frag_color = in.color;
 #       return out;
 #   }
-#   
+#
 #
 const fsSourceMetalMacos: array[411, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -391,14 +391,14 @@ proc noninterleavedShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
     of backendGlcore33:
       result.attrs[0].name = "position"
       result.attrs[1].name = "color0"
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceGlsl330))
+      result.vs.source = cast[cstring](addr(vsSourceGlsl330))
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
       result.vs.uniformBlocks[0].uniforms[0].name = "vs_params"
       result.vs.uniformBlocks[0].uniforms[0].type = uniformTypeFloat4
       result.vs.uniformBlocks[0].uniforms[0].arrayCount = 4
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceGlsl330))
+      result.fs.source = cast[cstring](addr(fsSourceGlsl330))
       result.fs.entry = "main"
       result.label = "noninterleavedShader"
     of backendD3d11:
@@ -406,21 +406,21 @@ proc noninterleavedShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.attrs[0].semIndex = 0
       result.attrs[1].semName = "TEXCOORD"
       result.attrs[1].semIndex = 1
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceHlsl4))
+      result.vs.source = cast[cstring](addr(vsSourceHlsl4))
       result.vs.d3d11Target = "vs_4_0"
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceHlsl4))
+      result.fs.source = cast[cstring](addr(fsSourceHlsl4))
       result.fs.d3d11Target = "ps_4_0"
       result.fs.entry = "main"
       result.label = "noninterleavedShader"
     of backendMetalMacos:
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceMetalMacos))
+      result.vs.source = cast[cstring](addr(vsSourceMetalMacos))
       result.vs.entry = "main0"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceMetalMacos))
+      result.fs.source = cast[cstring](addr(fsSourceMetalMacos))
       result.fs.entry = "main0"
       result.label = "noninterleavedShader"
     else: discard

--- a/examples/shaders/offscreen.nim
+++ b/examples/shaders/offscreen.nim
@@ -52,18 +52,18 @@ type VsParams* {.packed.} = object
 
 #
 #   #version 330
-#   
+#
 #   uniform vec4 vs_params[4];
 #   layout(location = 0) in vec4 position;
 #   out vec4 nrm;
 #   layout(location = 1) in vec4 normal;
-#   
+#
 #   void main()
 #   {
 #       gl_Position = mat4(vs_params[0], vs_params[1], vs_params[2], vs_params[3]) * position;
 #       nrm = normal;
 #   }
-#   
+#
 #
 const vsOffscreenSourceGlsl330: array[259, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x75,0x6e,
@@ -86,15 +86,15 @@ const vsOffscreenSourceGlsl330: array[259, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   layout(location = 0) out vec4 frag_color;
 #   in vec4 nrm;
-#   
+#
 #   void main()
 #   {
 #       frag_color = vec4((nrm.xyz * 0.5) + vec3(0.5), 1.0);
 #   }
-#   
+#
 #
 const fsOffscreenSourceGlsl330: array[145, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x6c,0x61,
@@ -110,14 +110,14 @@ const fsOffscreenSourceGlsl330: array[145, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   uniform vec4 vs_params[4];
 #   layout(location = 0) in vec4 position;
 #   out vec2 uv;
 #   layout(location = 2) in vec2 texcoord0;
 #   out vec4 nrm;
 #   layout(location = 1) in vec4 normal;
-#   
+#
 #   void main()
 #   {
 #       mat4 _24 = mat4(vs_params[0], vs_params[1], vs_params[2], vs_params[3]);
@@ -125,7 +125,7 @@ const fsOffscreenSourceGlsl330: array[145, uint8] = [
 #       uv = texcoord0;
 #       nrm = _24 * normal;
 #   }
-#   
+#
 #
 const vsDefaultSourceGlsl330: array[358, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x75,0x6e,
@@ -154,18 +154,18 @@ const vsDefaultSourceGlsl330: array[358, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   uniform sampler2D tex;
-#   
+#
 #   in vec2 uv;
 #   in vec4 nrm;
 #   layout(location = 0) out vec4 frag_color;
-#   
+#
 #   void main()
 #   {
 #       frag_color = vec4(texture(tex, uv * vec2(20.0, 10.0)).xyz * ((clamp(dot(nrm.xyz, vec3(0.57735025882720947265625, 0.57735025882720947265625, -0.57735025882720947265625)), 0.0, 1.0) * 2.0) + 0.25), 1.0);
 #   }
-#   
+#
 #
 const fsDefaultSourceGlsl330: array[330, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x75,0x6e,
@@ -195,25 +195,25 @@ const fsDefaultSourceGlsl330: array[330, uint8] = [
 #   {
 #       row_major float4x4 _21_mvp : packoffset(c0);
 #   };
-#   
-#   
+#
+#
 #   static float4 gl_Position;
 #   static float4 position;
 #   static float4 nrm;
 #   static float4 normal;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 position : TEXCOORD0;
 #       float4 normal : TEXCOORD1;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 nrm : TEXCOORD0;
 #       float4 gl_Position : SV_Position;
 #   };
-#   
+#
 #   #line 15 "examples/shaders/offscreen.glsl"
 #   void vert_main()
 #   {
@@ -222,7 +222,7 @@ const fsDefaultSourceGlsl330: array[330, uint8] = [
 #   #line 16 "examples/shaders/offscreen.glsl"
 #       nrm = normal;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       position = stage_input.position;
@@ -294,24 +294,24 @@ const vsOffscreenSourceHlsl4: array[867, uint8] = [
 #
 #   static float4 frag_color;
 #   static float4 nrm;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 nrm : TEXCOORD0;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 frag_color : SV_Target0;
 #   };
-#   
+#
 #   #line 10 "examples/shaders/offscreen.glsl"
 #   void frag_main()
 #   {
 #   #line 10 "examples/shaders/offscreen.glsl"
 #       frag_color = float4((nrm.xyz * 0.5f) + 0.5f.xxx, 1.0f);
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       nrm = stage_input.nrm;
@@ -363,29 +363,29 @@ const fsOffscreenSourceHlsl4: array[549, uint8] = [
 #   {
 #       row_major float4x4 _21_mvp : packoffset(c0);
 #   };
-#   
-#   
+#
+#
 #   static float4 gl_Position;
 #   static float4 position;
 #   static float2 uv;
 #   static float2 texcoord0;
 #   static float4 nrm;
 #   static float4 normal;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 position : TEXCOORD0;
 #       float4 normal : TEXCOORD1;
 #       float2 texcoord0 : TEXCOORD2;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 nrm : TEXCOORD0;
 #       float2 uv : TEXCOORD1;
 #       float4 gl_Position : SV_Position;
 #   };
-#   
+#
 #   #line 17 "examples/shaders/offscreen.glsl"
 #   void vert_main()
 #   {
@@ -396,7 +396,7 @@ const fsOffscreenSourceHlsl4: array[549, uint8] = [
 #   #line 19 "examples/shaders/offscreen.glsl"
 #       nrm = mul(normal, _21_mvp);
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       position = stage_input.position;
@@ -485,22 +485,22 @@ const vsDefaultSourceHlsl4: array[1113, uint8] = [
 #
 #   Texture2D<float4> tex : register(t0);
 #   SamplerState _tex_sampler : register(s0);
-#   
+#
 #   static float2 uv;
 #   static float4 nrm;
 #   static float4 frag_color;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 nrm : TEXCOORD0;
 #       float2 uv : TEXCOORD1;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 frag_color : SV_Target0;
 #   };
-#   
+#
 #   #line 14 "examples/shaders/offscreen.glsl"
 #   void frag_main()
 #   {
@@ -509,7 +509,7 @@ const vsDefaultSourceHlsl4: array[1113, uint8] = [
 #   #line 16 "examples/shaders/offscreen.glsl"
 #       frag_color = float4(tex.Sample(_tex_sampler, uv * float2(20.0f, 10.0f)).xyz * ((clamp(dot(nrm.xyz, float3(0.57735025882720947265625f, 0.57735025882720947265625f, -0.57735025882720947265625f)), 0.0f, 1.0f) * 2.0f) + 0.25f), 1.0f);
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       uv = stage_input.uv;
@@ -586,26 +586,26 @@ const fsDefaultSourceHlsl4: array[960, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct vs_params
 #   {
 #       float4x4 mvp;
 #   };
-#   
+#
 #   struct main0_out
 #   {
 #       float4 nrm [[user(locn0)]];
 #       float4 gl_Position [[position]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 position [[attribute(0)]];
 #       float4 normal [[attribute(1)]];
 #   };
-#   
+#
 #   #line 15 "examples/shaders/offscreen.glsl"
 #   vertex main0_out main0(main0_in in [[stage_in]], constant vs_params& _21 [[buffer(0)]])
 #   {
@@ -616,7 +616,7 @@ const fsDefaultSourceHlsl4: array[960, uint8] = [
 #       out.nrm = in.normal;
 #       return out;
 #   }
-#   
+#
 #
 const vsOffscreenSourceMetalMacos: array[634, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -663,19 +663,19 @@ const vsOffscreenSourceMetalMacos: array[634, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float4 frag_color [[color(0)]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 nrm [[user(locn0)]];
 #   };
-#   
+#
 #   #line 10 "examples/shaders/offscreen.glsl"
 #   fragment main0_out main0(main0_in in [[stage_in]])
 #   {
@@ -684,7 +684,7 @@ const vsOffscreenSourceMetalMacos: array[634, uint8] = [
 #       out.frag_color = float4((in.nrm.xyz * 0.5) + float3(0.5), 1.0);
 #       return out;
 #   }
-#   
+#
 #
 const fsOffscreenSourceMetalMacos: array[436, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -719,28 +719,28 @@ const fsOffscreenSourceMetalMacos: array[436, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct vs_params
 #   {
 #       float4x4 mvp;
 #   };
-#   
+#
 #   struct main0_out
 #   {
 #       float4 nrm [[user(locn0)]];
 #       float2 uv [[user(locn1)]];
 #       float4 gl_Position [[position]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 position [[attribute(0)]];
 #       float4 normal [[attribute(1)]];
 #       float2 texcoord0 [[attribute(2)]];
 #   };
-#   
+#
 #   #line 17 "examples/shaders/offscreen.glsl"
 #   vertex main0_out main0(main0_in in [[stage_in]], constant vs_params& _21 [[buffer(0)]])
 #   {
@@ -753,7 +753,7 @@ const fsOffscreenSourceMetalMacos: array[436, uint8] = [
 #       out.nrm = _21.mvp * in.normal;
 #       return out;
 #   }
-#   
+#
 #
 const vsDefaultSourceMetalMacos: array[784, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -810,20 +810,20 @@ const vsDefaultSourceMetalMacos: array[784, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float4 frag_color [[color(0)]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 nrm [[user(locn0)]];
 #       float2 uv [[user(locn1)]];
 #   };
-#   
+#
 #   #line 14 "examples/shaders/offscreen.glsl"
 #   fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> tex [[texture(0)]], sampler texSmplr [[sampler(0)]])
 #   {
@@ -834,7 +834,7 @@ const vsDefaultSourceMetalMacos: array[784, uint8] = [
 #       out.frag_color = float4(tex.sample(texSmplr, (in.uv * float2(20.0, 10.0))).xyz * ((fast::clamp(dot(in.nrm.xyz, float3(0.57735025882720947265625, 0.57735025882720947265625, -0.57735025882720947265625)), 0.0, 1.0) * 2.0) + 0.25), 1.0);
 #       return out;
 #   }
-#   
+#
 #
 const fsDefaultSourceMetalMacos: array[793, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -894,14 +894,14 @@ proc defaultShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.attrs[0].name = "position"
       result.attrs[1].name = "normal"
       result.attrs[2].name = "texcoord0"
-      result.vs.source = cast[cstring](unsafeAddr(vsDefaultSourceGlsl330))
+      result.vs.source = cast[cstring](addr(vsDefaultSourceGlsl330))
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
       result.vs.uniformBlocks[0].uniforms[0].name = "vs_params"
       result.vs.uniformBlocks[0].uniforms[0].type = uniformTypeFloat4
       result.vs.uniformBlocks[0].uniforms[0].arrayCount = 4
-      result.fs.source = cast[cstring](unsafeAddr(fsDefaultSourceGlsl330))
+      result.fs.source = cast[cstring](addr(fsDefaultSourceGlsl330))
       result.fs.entry = "main"
       result.fs.images[0].name = "tex"
       result.fs.images[0].imageType = imageType2d
@@ -914,12 +914,12 @@ proc defaultShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.attrs[1].semIndex = 1
       result.attrs[2].semName = "TEXCOORD"
       result.attrs[2].semIndex = 2
-      result.vs.source = cast[cstring](unsafeAddr(vsDefaultSourceHlsl4))
+      result.vs.source = cast[cstring](addr(vsDefaultSourceHlsl4))
       result.vs.d3d11Target = "vs_4_0"
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsDefaultSourceHlsl4))
+      result.fs.source = cast[cstring](addr(fsDefaultSourceHlsl4))
       result.fs.d3d11Target = "ps_4_0"
       result.fs.entry = "main"
       result.fs.images[0].name = "tex"
@@ -927,11 +927,11 @@ proc defaultShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.fs.images[0].samplerType = samplerTypeFloat
       result.label = "defaultShader"
     of backendMetalMacos:
-      result.vs.source = cast[cstring](unsafeAddr(vsDefaultSourceMetalMacos))
+      result.vs.source = cast[cstring](addr(vsDefaultSourceMetalMacos))
       result.vs.entry = "main0"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsDefaultSourceMetalMacos))
+      result.fs.source = cast[cstring](addr(fsDefaultSourceMetalMacos))
       result.fs.entry = "main0"
       result.fs.images[0].name = "tex"
       result.fs.images[0].imageType = imageType2d
@@ -944,14 +944,14 @@ proc offscreenShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
     of backendGlcore33:
       result.attrs[0].name = "position"
       result.attrs[1].name = "normal"
-      result.vs.source = cast[cstring](unsafeAddr(vsOffscreenSourceGlsl330))
+      result.vs.source = cast[cstring](addr(vsOffscreenSourceGlsl330))
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
       result.vs.uniformBlocks[0].uniforms[0].name = "vs_params"
       result.vs.uniformBlocks[0].uniforms[0].type = uniformTypeFloat4
       result.vs.uniformBlocks[0].uniforms[0].arrayCount = 4
-      result.fs.source = cast[cstring](unsafeAddr(fsOffscreenSourceGlsl330))
+      result.fs.source = cast[cstring](addr(fsOffscreenSourceGlsl330))
       result.fs.entry = "main"
       result.label = "offscreenShader"
     of backendD3d11:
@@ -959,21 +959,21 @@ proc offscreenShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.attrs[0].semIndex = 0
       result.attrs[1].semName = "TEXCOORD"
       result.attrs[1].semIndex = 1
-      result.vs.source = cast[cstring](unsafeAddr(vsOffscreenSourceHlsl4))
+      result.vs.source = cast[cstring](addr(vsOffscreenSourceHlsl4))
       result.vs.d3d11Target = "vs_4_0"
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsOffscreenSourceHlsl4))
+      result.fs.source = cast[cstring](addr(fsOffscreenSourceHlsl4))
       result.fs.d3d11Target = "ps_4_0"
       result.fs.entry = "main"
       result.label = "offscreenShader"
     of backendMetalMacos:
-      result.vs.source = cast[cstring](unsafeAddr(vsOffscreenSourceMetalMacos))
+      result.vs.source = cast[cstring](addr(vsOffscreenSourceMetalMacos))
       result.vs.entry = "main0"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsOffscreenSourceMetalMacos))
+      result.fs.source = cast[cstring](addr(fsOffscreenSourceMetalMacos))
       result.fs.entry = "main0"
       result.label = "offscreenShader"
     else: discard

--- a/examples/shaders/quad.nim
+++ b/examples/shaders/quad.nim
@@ -24,17 +24,17 @@ const attrVsColor0* = 1
 
 #
 #   #version 330
-#   
+#
 #   layout(location = 0) in vec4 position;
 #   out vec4 color;
 #   layout(location = 1) in vec4 color0;
-#   
+#
 #   void main()
 #   {
 #       gl_Position = position;
 #       color = color0;
 #   }
-#   
+#
 #
 const vsSourceGlsl330: array[173, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x6c,0x61,
@@ -51,15 +51,15 @@ const vsSourceGlsl330: array[173, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   layout(location = 0) out vec4 frag_color;
 #   in vec4 color;
-#   
+#
 #   void main()
 #   {
 #       frag_color = color;
 #   }
-#   
+#
 #
 const fsSourceGlsl330: array[114, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x6c,0x61,
@@ -76,19 +76,19 @@ const fsSourceGlsl330: array[114, uint8] = [
 #   static float4 position;
 #   static float4 color;
 #   static float4 color0;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 position : TEXCOORD0;
 #       float4 color0 : TEXCOORD1;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 color : TEXCOORD0;
 #       float4 gl_Position : SV_Position;
 #   };
-#   
+#
 #   #line 11 "examples/shaders/quad.glsl"
 #   void vert_main()
 #   {
@@ -97,7 +97,7 @@ const fsSourceGlsl330: array[114, uint8] = [
 #   #line 12 "examples/shaders/quad.glsl"
 #       color = color0;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       position = stage_input.position;
@@ -162,24 +162,24 @@ const vsSourceHlsl4: array[759, uint8] = [
 #
 #   static float4 frag_color;
 #   static float4 color;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 color : TEXCOORD0;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 frag_color : SV_Target0;
 #   };
-#   
+#
 #   #line 10 "examples/shaders/quad.glsl"
 #   void frag_main()
 #   {
 #   #line 10 "examples/shaders/quad.glsl"
 #       frag_color = color;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       color = stage_input.color;
@@ -226,21 +226,21 @@ const fsSourceHlsl4: array[511, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float4 color [[user(locn0)]];
 #       float4 gl_Position [[position]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 position [[attribute(0)]];
 #       float4 color0 [[attribute(1)]];
 #   };
-#   
+#
 #   #line 11 "examples/shaders/quad.glsl"
 #   vertex main0_out main0(main0_in in [[stage_in]])
 #   {
@@ -251,7 +251,7 @@ const fsSourceHlsl4: array[511, uint8] = [
 #       out.color = in.color0;
 #       return out;
 #   }
-#   
+#
 #
 const vsSourceMetalMacos: array[533, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -292,19 +292,19 @@ const vsSourceMetalMacos: array[533, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float4 frag_color [[color(0)]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 color [[user(locn0)]];
 #   };
-#   
+#
 #   #line 10 "examples/shaders/quad.glsl"
 #   fragment main0_out main0(main0_in in [[stage_in]])
 #   {
@@ -313,7 +313,7 @@ const vsSourceMetalMacos: array[533, uint8] = [
 #       out.frag_color = in.color;
 #       return out;
 #   }
-#   
+#
 #
 const fsSourceMetalMacos: array[391, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -347,9 +347,9 @@ proc quadShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
     of backendGlcore33:
       result.attrs[0].name = "position"
       result.attrs[1].name = "color0"
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceGlsl330))
+      result.vs.source = cast[cstring](addr(vsSourceGlsl330))
       result.vs.entry = "main"
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceGlsl330))
+      result.fs.source = cast[cstring](addr(fsSourceGlsl330))
       result.fs.entry = "main"
       result.label = "quadShader"
     of backendD3d11:
@@ -357,17 +357,17 @@ proc quadShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.attrs[0].semIndex = 0
       result.attrs[1].semName = "TEXCOORD"
       result.attrs[1].semIndex = 1
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceHlsl4))
+      result.vs.source = cast[cstring](addr(vsSourceHlsl4))
       result.vs.d3d11Target = "vs_4_0"
       result.vs.entry = "main"
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceHlsl4))
+      result.fs.source = cast[cstring](addr(fsSourceHlsl4))
       result.fs.d3d11Target = "ps_4_0"
       result.fs.entry = "main"
       result.label = "quadShader"
     of backendMetalMacos:
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceMetalMacos))
+      result.vs.source = cast[cstring](addr(vsSourceMetalMacos))
       result.vs.entry = "main0"
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceMetalMacos))
+      result.fs.source = cast[cstring](addr(fsSourceMetalMacos))
       result.fs.entry = "main0"
       result.label = "quadShader"
     else: discard

--- a/examples/shaders/shapes.nim
+++ b/examples/shaders/shapes.nim
@@ -38,14 +38,14 @@ type VsParams* {.packed.} = object
 
 #
 #   #version 330
-#   
+#
 #   uniform vec4 vs_params[5];
 #   layout(location = 0) in vec4 position;
 #   out vec4 color;
 #   layout(location = 1) in vec3 normal;
 #   layout(location = 2) in vec2 texcoord;
 #   layout(location = 3) in vec4 color0;
-#   
+#
 #   void main()
 #   {
 #       gl_Position = mat4(vs_params[0], vs_params[1], vs_params[2], vs_params[3]) * position;
@@ -65,7 +65,7 @@ type VsParams* {.packed.} = object
 #           }
 #       }
 #   }
-#   
+#
 #
 const vsSourceGlsl330: array[600, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x75,0x6e,
@@ -109,15 +109,15 @@ const vsSourceGlsl330: array[600, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   layout(location = 0) out vec4 frag_color;
 #   in vec4 color;
-#   
+#
 #   void main()
 #   {
 #       frag_color = color;
 #   }
-#   
+#
 #
 const fsSourceGlsl330: array[114, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x6c,0x61,
@@ -135,15 +135,15 @@ const fsSourceGlsl330: array[114, uint8] = [
 #       row_major float4x4 _21_mvp : packoffset(c0);
 #       float _21_draw_mode : packoffset(c4);
 #   };
-#   
-#   
+#
+#
 #   static float4 gl_Position;
 #   static float4 position;
 #   static float4 color;
 #   static float3 normal;
 #   static float2 texcoord;
 #   static float4 color0;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 position : TEXCOORD0;
@@ -151,13 +151,13 @@ const fsSourceGlsl330: array[114, uint8] = [
 #       float2 texcoord : TEXCOORD2;
 #       float4 color0 : TEXCOORD3;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 color : TEXCOORD0;
 #       float4 gl_Position : SV_Position;
 #   };
-#   
+#
 #   #line 19 "examples/shaders/shapes.glsl"
 #   void vert_main()
 #   {
@@ -184,7 +184,7 @@ const fsSourceGlsl330: array[114, uint8] = [
 #           }
 #       }
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       position = stage_input.position;
@@ -298,24 +298,24 @@ const vsSourceHlsl4: array[1518, uint8] = [
 #
 #   static float4 frag_color;
 #   static float4 color;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 color : TEXCOORD0;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 frag_color : SV_Target0;
 #   };
-#   
+#
 #   #line 10 "examples/shaders/shapes.glsl"
 #   void frag_main()
 #   {
 #   #line 10 "examples/shaders/shapes.glsl"
 #       frag_color = color;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       color = stage_input.color;
@@ -363,21 +363,21 @@ const fsSourceHlsl4: array[515, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct vs_params
 #   {
 #       float4x4 mvp;
 #       float draw_mode;
 #   };
-#   
+#
 #   struct main0_out
 #   {
 #       float4 color [[user(locn0)]];
 #       float4 gl_Position [[position]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 position [[attribute(0)]];
@@ -385,7 +385,7 @@ const fsSourceHlsl4: array[515, uint8] = [
 #       float2 texcoord [[attribute(2)]];
 #       float4 color0 [[attribute(3)]];
 #   };
-#   
+#
 #   #line 19 "examples/shaders/shapes.glsl"
 #   vertex main0_out main0(main0_in in [[stage_in]], constant vs_params& _21 [[buffer(0)]])
 #   {
@@ -414,7 +414,7 @@ const fsSourceHlsl4: array[515, uint8] = [
 #       }
 #       return out;
 #   }
-#   
+#
 #
 const vsSourceMetalMacos: array[1163, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -494,19 +494,19 @@ const vsSourceMetalMacos: array[1163, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float4 frag_color [[color(0)]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 color [[user(locn0)]];
 #   };
-#   
+#
 #   #line 10 "examples/shaders/shapes.glsl"
 #   fragment main0_out main0(main0_in in [[stage_in]])
 #   {
@@ -515,7 +515,7 @@ const vsSourceMetalMacos: array[1163, uint8] = [
 #       out.frag_color = in.color;
 #       return out;
 #   }
-#   
+#
 #
 const fsSourceMetalMacos: array[395, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -551,14 +551,14 @@ proc shapesShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.attrs[1].name = "normal"
       result.attrs[2].name = "texcoord"
       result.attrs[3].name = "color0"
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceGlsl330))
+      result.vs.source = cast[cstring](addr(vsSourceGlsl330))
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 80
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
       result.vs.uniformBlocks[0].uniforms[0].name = "vs_params"
       result.vs.uniformBlocks[0].uniforms[0].type = uniformTypeFloat4
       result.vs.uniformBlocks[0].uniforms[0].arrayCount = 5
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceGlsl330))
+      result.fs.source = cast[cstring](addr(fsSourceGlsl330))
       result.fs.entry = "main"
       result.label = "shapesShader"
     of backendD3d11:
@@ -570,21 +570,21 @@ proc shapesShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.attrs[2].semIndex = 2
       result.attrs[3].semName = "TEXCOORD"
       result.attrs[3].semIndex = 3
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceHlsl4))
+      result.vs.source = cast[cstring](addr(vsSourceHlsl4))
       result.vs.d3d11Target = "vs_4_0"
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 80
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceHlsl4))
+      result.fs.source = cast[cstring](addr(fsSourceHlsl4))
       result.fs.d3d11Target = "ps_4_0"
       result.fs.entry = "main"
       result.label = "shapesShader"
     of backendMetalMacos:
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceMetalMacos))
+      result.vs.source = cast[cstring](addr(vsSourceMetalMacos))
       result.vs.entry = "main0"
       result.vs.uniformBlocks[0].size = 80
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceMetalMacos))
+      result.fs.source = cast[cstring](addr(fsSourceMetalMacos))
       result.fs.entry = "main0"
       result.label = "shapesShader"
     else: discard

--- a/examples/shaders/texcube.nim
+++ b/examples/shaders/texcube.nim
@@ -39,21 +39,21 @@ type VsParams* {.packed.} = object
 
 #
 #   #version 330
-#   
+#
 #   uniform vec4 vs_params[4];
 #   layout(location = 0) in vec4 pos;
 #   out vec4 color;
 #   layout(location = 1) in vec4 color0;
 #   out vec2 uv;
 #   layout(location = 2) in vec2 texcoord0;
-#   
+#
 #   void main()
 #   {
 #       gl_Position = mat4(vs_params[0], vs_params[1], vs_params[2], vs_params[3]) * pos;
 #       color = color0;
 #       uv = texcoord0 * 5.0;
 #   }
-#   
+#
 #
 const vsSourceGlsl330: array[332, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x75,0x6e,
@@ -80,18 +80,18 @@ const vsSourceGlsl330: array[332, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   uniform sampler2D tex;
-#   
+#
 #   layout(location = 0) out vec4 frag_color;
 #   in vec2 uv;
 #   in vec4 color;
-#   
+#
 #   void main()
 #   {
 #       frag_color = texture(tex, uv) * color;
 #   }
-#   
+#
 #
 const fsSourceGlsl330: array[169, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x75,0x6e,
@@ -111,29 +111,29 @@ const fsSourceGlsl330: array[169, uint8] = [
 #   {
 #       row_major float4x4 _21_mvp : packoffset(c0);
 #   };
-#   
-#   
+#
+#
 #   static float4 gl_Position;
 #   static float4 pos;
 #   static float4 color;
 #   static float4 color0;
 #   static float2 uv;
 #   static float2 texcoord0;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 pos : TEXCOORD0;
 #       float4 color0 : TEXCOORD1;
 #       float2 texcoord0 : TEXCOORD2;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 color : TEXCOORD0;
 #       float2 uv : TEXCOORD1;
 #       float4 gl_Position : SV_Position;
 #   };
-#   
+#
 #   #line 18 "examples/shaders/texcube.glsl"
 #   void vert_main()
 #   {
@@ -144,7 +144,7 @@ const fsSourceGlsl330: array[169, uint8] = [
 #   #line 20 "examples/shaders/texcube.glsl"
 #       uv = texcoord0 * 5.0f;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       pos = stage_input.pos;
@@ -231,29 +231,29 @@ const vsSourceHlsl4: array[1083, uint8] = [
 #
 #   Texture2D<float4> tex : register(t0);
 #   SamplerState _tex_sampler : register(s0);
-#   
+#
 #   static float4 frag_color;
 #   static float2 uv;
 #   static float4 color;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 color : TEXCOORD0;
 #       float2 uv : TEXCOORD1;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 frag_color : SV_Target0;
 #   };
-#   
+#
 #   #line 13 "examples/shaders/texcube.glsl"
 #   void frag_main()
 #   {
 #   #line 13 "examples/shaders/texcube.glsl"
 #       frag_color = tex.Sample(_tex_sampler, uv) * color;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       uv = stage_input.uv;
@@ -313,28 +313,28 @@ const fsSourceHlsl4: array[699, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct vs_params
 #   {
 #       float4x4 mvp;
 #   };
-#   
+#
 #   struct main0_out
 #   {
 #       float4 color [[user(locn0)]];
 #       float2 uv [[user(locn1)]];
 #       float4 gl_Position [[position]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 pos [[attribute(0)]];
 #       float4 color0 [[attribute(1)]];
 #       float2 texcoord0 [[attribute(2)]];
 #   };
-#   
+#
 #   #line 18 "examples/shaders/texcube.glsl"
 #   vertex main0_out main0(main0_in in [[stage_in]], constant vs_params& _21 [[buffer(0)]])
 #   {
@@ -347,7 +347,7 @@ const fsSourceHlsl4: array[699, uint8] = [
 #       out.uv = in.texcoord0 * 5.0;
 #       return out;
 #   }
-#   
+#
 #
 const vsSourceMetalMacos: array[766, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -402,20 +402,20 @@ const vsSourceMetalMacos: array[766, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float4 frag_color [[color(0)]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 color [[user(locn0)]];
 #       float2 uv [[user(locn1)]];
 #   };
-#   
+#
 #   #line 13 "examples/shaders/texcube.glsl"
 #   fragment main0_out main0(main0_in in [[stage_in]], texture2d<float> tex [[texture(0)]], sampler texSmplr [[sampler(0)]])
 #   {
@@ -424,7 +424,7 @@ const vsSourceMetalMacos: array[766, uint8] = [
 #       out.frag_color = tex.sample(texSmplr, in.uv) * in.color;
 #       return out;
 #   }
-#   
+#
 #
 const fsSourceMetalMacos: array[528, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -468,14 +468,14 @@ proc texcubeShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.attrs[0].name = "pos"
       result.attrs[1].name = "color0"
       result.attrs[2].name = "texcoord0"
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceGlsl330))
+      result.vs.source = cast[cstring](addr(vsSourceGlsl330))
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
       result.vs.uniformBlocks[0].uniforms[0].name = "vs_params"
       result.vs.uniformBlocks[0].uniforms[0].type = uniformTypeFloat4
       result.vs.uniformBlocks[0].uniforms[0].arrayCount = 4
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceGlsl330))
+      result.fs.source = cast[cstring](addr(fsSourceGlsl330))
       result.fs.entry = "main"
       result.fs.images[0].name = "tex"
       result.fs.images[0].imageType = imageType2d
@@ -488,12 +488,12 @@ proc texcubeShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.attrs[1].semIndex = 1
       result.attrs[2].semName = "TEXCOORD"
       result.attrs[2].semIndex = 2
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceHlsl4))
+      result.vs.source = cast[cstring](addr(vsSourceHlsl4))
       result.vs.d3d11Target = "vs_4_0"
       result.vs.entry = "main"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceHlsl4))
+      result.fs.source = cast[cstring](addr(fsSourceHlsl4))
       result.fs.d3d11Target = "ps_4_0"
       result.fs.entry = "main"
       result.fs.images[0].name = "tex"
@@ -501,11 +501,11 @@ proc texcubeShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.fs.images[0].samplerType = samplerTypeFloat
       result.label = "texcubeShader"
     of backendMetalMacos:
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceMetalMacos))
+      result.vs.source = cast[cstring](addr(vsSourceMetalMacos))
       result.vs.entry = "main0"
       result.vs.uniformBlocks[0].size = 64
       result.vs.uniformBlocks[0].layout = uniformLayoutStd140
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceMetalMacos))
+      result.fs.source = cast[cstring](addr(fsSourceMetalMacos))
       result.fs.entry = "main0"
       result.fs.images[0].name = "tex"
       result.fs.images[0].imageType = imageType2d

--- a/examples/shaders/triangle.nim
+++ b/examples/shaders/triangle.nim
@@ -24,17 +24,17 @@ const attrVsColor0* = 1
 
 #
 #   #version 330
-#   
+#
 #   layout(location = 0) in vec4 position;
 #   out vec4 color;
 #   layout(location = 1) in vec4 color0;
-#   
+#
 #   void main()
 #   {
 #       gl_Position = position;
 #       color = color0;
 #   }
-#   
+#
 #
 const vsSourceGlsl330: array[173, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x6c,0x61,
@@ -51,15 +51,15 @@ const vsSourceGlsl330: array[173, uint8] = [
 ]
 #
 #   #version 330
-#   
+#
 #   layout(location = 0) out vec4 frag_color;
 #   in vec4 color;
-#   
+#
 #   void main()
 #   {
 #       frag_color = color;
 #   }
-#   
+#
 #
 const fsSourceGlsl330: array[114, uint8] = [
     0x23'u8,0x76,0x65,0x72,0x73,0x69,0x6f,0x6e,0x20,0x33,0x33,0x30,0x0a,0x0a,0x6c,0x61,
@@ -76,19 +76,19 @@ const fsSourceGlsl330: array[114, uint8] = [
 #   static float4 position;
 #   static float4 color;
 #   static float4 color0;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 position : TEXCOORD0;
 #       float4 color0 : TEXCOORD1;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 color : TEXCOORD0;
 #       float4 gl_Position : SV_Position;
 #   };
-#   
+#
 #   #line 12 "examples/shaders/triangle.glsl"
 #   void vert_main()
 #   {
@@ -97,7 +97,7 @@ const fsSourceGlsl330: array[114, uint8] = [
 #   #line 13 "examples/shaders/triangle.glsl"
 #       color = color0;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       position = stage_input.position;
@@ -163,24 +163,24 @@ const vsSourceHlsl4: array[771, uint8] = [
 #
 #   static float4 frag_color;
 #   static float4 color;
-#   
+#
 #   struct SPIRV_Cross_Input
 #   {
 #       float4 color : TEXCOORD0;
 #   };
-#   
+#
 #   struct SPIRV_Cross_Output
 #   {
 #       float4 frag_color : SV_Target0;
 #   };
-#   
+#
 #   #line 10 "examples/shaders/triangle.glsl"
 #   void frag_main()
 #   {
 #   #line 10 "examples/shaders/triangle.glsl"
 #       frag_color = color;
 #   }
-#   
+#
 #   SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
 #   {
 #       color = stage_input.color;
@@ -228,21 +228,21 @@ const fsSourceHlsl4: array[519, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float4 color [[user(locn0)]];
 #       float4 gl_Position [[position]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 position [[attribute(0)]];
 #       float4 color0 [[attribute(1)]];
 #   };
-#   
+#
 #   #line 12 "examples/shaders/triangle.glsl"
 #   vertex main0_out main0(main0_in in [[stage_in]])
 #   {
@@ -253,7 +253,7 @@ const fsSourceHlsl4: array[519, uint8] = [
 #       out.color = in.color0;
 #       return out;
 #   }
-#   
+#
 #
 const vsSourceMetalMacos: array[545, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -295,19 +295,19 @@ const vsSourceMetalMacos: array[545, uint8] = [
 #
 #   #include <metal_stdlib>
 #   #include <simd/simd.h>
-#   
+#
 #   using namespace metal;
-#   
+#
 #   struct main0_out
 #   {
 #       float4 frag_color [[color(0)]];
 #   };
-#   
+#
 #   struct main0_in
 #   {
 #       float4 color [[user(locn0)]];
 #   };
-#   
+#
 #   #line 10 "examples/shaders/triangle.glsl"
 #   fragment main0_out main0(main0_in in [[stage_in]])
 #   {
@@ -316,7 +316,7 @@ const vsSourceMetalMacos: array[545, uint8] = [
 #       out.frag_color = in.color;
 #       return out;
 #   }
-#   
+#
 #
 const fsSourceMetalMacos: array[399, uint8] = [
     0x23'u8,0x69,0x6e,0x63,0x6c,0x75,0x64,0x65,0x20,0x3c,0x6d,0x65,0x74,0x61,0x6c,0x5f,
@@ -350,9 +350,9 @@ proc triangleShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
     of backendGlcore33:
       result.attrs[0].name = "position"
       result.attrs[1].name = "color0"
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceGlsl330))
+      result.vs.source = cast[cstring](addr(vsSourceGlsl330))
       result.vs.entry = "main"
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceGlsl330))
+      result.fs.source = cast[cstring](addr(fsSourceGlsl330))
       result.fs.entry = "main"
       result.label = "triangleShader"
     of backendD3d11:
@@ -360,17 +360,17 @@ proc triangleShaderDesc*(backend: sg.Backend): sg.ShaderDesc =
       result.attrs[0].semIndex = 0
       result.attrs[1].semName = "TEXCOORD"
       result.attrs[1].semIndex = 1
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceHlsl4))
+      result.vs.source = cast[cstring](addr(vsSourceHlsl4))
       result.vs.d3d11Target = "vs_4_0"
       result.vs.entry = "main"
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceHlsl4))
+      result.fs.source = cast[cstring](addr(fsSourceHlsl4))
       result.fs.d3d11Target = "ps_4_0"
       result.fs.entry = "main"
       result.label = "triangleShader"
     of backendMetalMacos:
-      result.vs.source = cast[cstring](unsafeAddr(vsSourceMetalMacos))
+      result.vs.source = cast[cstring](addr(vsSourceMetalMacos))
       result.vs.entry = "main0"
-      result.fs.source = cast[cstring](unsafeAddr(fsSourceMetalMacos))
+      result.fs.source = cast[cstring](addr(fsSourceMetalMacos))
       result.fs.entry = "main0"
       result.label = "triangleShader"
     else: discard

--- a/examples/shapes.nim
+++ b/examples/shapes.nim
@@ -70,8 +70,8 @@ proc init() {.cdecl.} =
   var vertices: array[6 * 1024, sshape.Vertex]
   var indices: array[16 * 1024, uint16]
   var buf = sshape.Buffer(
-    vertices: BufferItem(buffer: sshape.Range(addr: vertices.unsafeAddr, size: vertices.sizeof)),
-    indices: BufferItem(buffer: sshape.Range(addr: indices.unsafeAddr, size: indices.sizeof))
+    vertices: BufferItem(buffer: sshape.Range(addr: vertices.addr, size: vertices.sizeof)),
+    indices: BufferItem(buffer: sshape.Range(addr: indices.addr, size: indices.sizeof))
   )
   buf = sshape.buildBox(buf, Box(width: 1f, height: 1f, depth: 1f, tiles: 10, randomColors: true))
   shapes[0].draw = sshape.elementRange(buf)
@@ -120,7 +120,7 @@ proc frame() {.cdecl.} =
     let model = translate(shapes[i].pos) * rm
     # model-view-proj matrix
     vsParams.mvp = viewProj * model
-    sg.applyUniforms(shaderStageVs, shd.slotVsParams, sg.Range(addr: vsParams.unsafeAddr, size: vsParams.sizeof))
+    sg.applyUniforms(shaderStageVs, shd.slotVsParams, sg.Range(addr: vsParams.addr, size: vsParams.sizeof))
     sg.draw(shapes[i].draw.baseElement, shapes[i].draw.numElements, 1)
   sdtx.draw()
   sg.endPass()

--- a/examples/texcube.nim
+++ b/examples/texcube.nim
@@ -67,7 +67,7 @@ proc init() {.cdecl.} =
     Vertex( x:  1.0, y:  1.0, z: -1.0,  color: 0xFF007FFF'u32, u:     0, v: 32767 ),
   ]
   bindings.vertexBuffers[0] = sg.makeBuffer(BufferDesc(
-    data: sg.Range(addr: vertices.unsafeAddr, size: vertices.sizeof)
+    data: sg.Range(addr: vertices.addr, size: vertices.sizeof)
   ))
 
   # create an index buffer for the cube
@@ -81,7 +81,7 @@ proc init() {.cdecl.} =
   ]
   bindings.indexBuffer = sg.makeBuffer(BufferDesc(
     type: bufferTypeIndexBuffer,
-    data: sg.Range(addr: indices.unsafeAddr, size: indices.sizeof)
+    data: sg.Range(addr: indices.addr, size: indices.sizeof)
   ))
 
   # create a checker board texture
@@ -95,7 +95,7 @@ proc init() {.cdecl.} =
     width: 4,
     height: 4,
     data: ImageData(
-      subimage: [ [ sg.Range(addr: pixels.unsafeAddr, size: pixels.sizeof) ] ]
+      subimage: [ [ sg.Range(addr: pixels.addr, size: pixels.sizeof) ] ]
     )
   ))
 
@@ -133,7 +133,7 @@ proc frame() {.cdecl.} =
   sg.beginDefaultPass(passAction, sapp.width(), sapp.height())
   sg.applyPipeline(pip)
   sg.applyBindings(bindings)
-  sg.applyUniforms(shaderStageVs, shd.slotVsParams, sg.Range(addr: vsParams.unsafeAddr, size: vsParams.sizeof))
+  sg.applyUniforms(shaderStageVs, shd.slotVsParams, sg.Range(addr: vsParams.addr, size: vsParams.sizeof))
   sg.draw(0, 36, 1)
   sg.endPass()
   sg.commit()

--- a/examples/triangle.nim
+++ b/examples/triangle.nim
@@ -26,7 +26,7 @@ proc init() {.cdecl.} =
     -0.5, -0.5, 0.5,     0.0, 0.0, 1.0, 1.0
   ]
   bindings.vertexBuffers[0] = sg.makeBuffer(BufferDesc(
-    data: sg.Range(addr: vertices.unsafeAddr, size: vertices.sizeof)
+    data: sg.Range(addr: vertices.addr, size: vertices.sizeof)
   ))
 
   # create shader and pipeline object


### PR DESCRIPTION
```
warning:: `unsafeAddr` is a deprecated alias for `addr`, 
use `addr` instead.
```
nim devel (v1.9+) deprecate unsafeAddr, Nim may upgrade to v2.0 in a few months or next year (maybe)