### PR TITLE
Check for NDEBUG flag when defining SOKOL_ASSERT

### DIFF
--- a/src/sokol/c/sokol_defines.h
+++ b/src/sokol/c/sokol_defines.h
@@ -2,7 +2,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define SOKOL_ASSERT(x) ((x)?(1):(sokol_assert_failed(__FILE__,__LINE__,#x),0))
+#ifndef NDEBUG
+    #define SOKOL_ASSERT(x) ((x)?(1):(sokol_assert_failed(__FILE__,__LINE__,#x),0))
+#endif
 
 static inline void
 sokol_assert_failed(const char* file, int line, const char* expr) {


### PR DESCRIPTION
See issue #24 . This only adds the check for NDEBUG, it does not add the switch in release mode as it seems that would need to be added to the code generator which is in a separate repository.